### PR TITLE
github: Make actions only run on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
 name: CMake build
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -1,10 +1,9 @@
 name: clang-format
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   clang_format:


### PR DESCRIPTION
Remove push trigger from both actions (build, clang-format), since it's also triggering when merging a pull request. So basically actions run twice - first in PR, then on merge.

Also add a manual dispatch trigger for both, if for whatever reason they need to be run with no code changes.