### PR TITLE
Add scrollables

### DIFF
--- a/src/consts.hpp
+++ b/src/consts.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include <SFML/Graphics/BlendMode.hpp>
+#include <SFML/Graphics/Color.hpp>
 
 const std::string CONFUSION = "???";
 
@@ -47,6 +48,8 @@ typedef unsigned int uint;
 #ifndef uchar
 typedef unsigned char uchar;
 #endif
+
+using StringAndColor = std::pair<std::string, sf::Color>;
 
 enum GameState
 {

--- a/src/hud/buttons/button_consts.hpp
+++ b/src/hud/buttons/button_consts.hpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// (c) 2024 h67ma <szycikm@gmail.com>
+
+#pragma once
+
+constexpr float BTN_SIMPLE_BIG_WIDTH = 128;
+constexpr float BTN_SIMPLE_BIG_HEIGHT = 65;
+constexpr float BTN_SIMPLE_NARROW_WIDTH = 131;
+constexpr float BTN_SIMPLE_NARROW_HEIGHT = 27;
+constexpr float BTN_SIMPLE_NORMAL_WIDTH = 187;
+constexpr float BTN_SIMPLE_NORMAL_HEIGHT = 27;

--- a/src/hud/buttons/simple_button.cpp
+++ b/src/hud/buttons/simple_button.cpp
@@ -11,6 +11,7 @@
 
 #include "../../settings/settings_manager.hpp"
 #include "../../util/util.hpp"
+#include "button_consts.hpp"
 
 constexpr uint BTN_TEXT_TOP_OFFSET = 12;
 
@@ -86,30 +87,24 @@ void SimpleButton::setColor()
 
 void SimpleButton::setGuiScale()
 {
-	sf::Vector2u dim;
+	sf::Vector2f dim;
 
 	this->text.handleSettingsChange();
 
 	switch (this->size)
 	{
 		case BTN_BIG:
-			dim.x = 128;
-			dim.y = 65;
+			dim = calculateGuiAwarePoint({ BTN_SIMPLE_BIG_WIDTH, BTN_SIMPLE_BIG_HEIGHT });
 			break;
 		case BTN_NARROW:
-			dim.x = 131;
-			dim.y = 27;
+			dim = calculateGuiAwarePoint({ BTN_SIMPLE_NARROW_WIDTH, BTN_SIMPLE_NARROW_HEIGHT });
 			break;
 		case BTN_NORMAL:
 		default:
-			dim.x = 187;
-			dim.y = 27;
+			dim = calculateGuiAwarePoint({ BTN_SIMPLE_NORMAL_WIDTH, BTN_SIMPLE_NORMAL_HEIGHT });
 	}
 
-	dim.x *= SettingsManager::guiScale;
-	dim.y *= SettingsManager::guiScale;
-
-	this->rect.setSize(static_cast<sf::Vector2f>(dim));
+	this->rect.setSize(dim);
 	this->setThickness();
 
 	// gradient fill (transparent - almost black - transparent)
@@ -122,21 +117,21 @@ void SimpleButton::setGuiScale()
 	// 3 -- 2
 
 	// left half
-	gradient[0] = sf::Vertex({ 0.F, 0.F }, sf::Color::Transparent);
-	gradient[1] = sf::Vertex({ midX, 0.F }, COLOR_BUTTON_BG_BLACK);
-	gradient[2] = sf::Vertex({ midX, static_cast<float>(dim.y) }, COLOR_BUTTON_BG_BLACK);
-	gradient[3] = sf::Vertex({ 0.F, static_cast<float>(dim.y) }, sf::Color::Transparent);
+	gradient[0] = sf::Vertex({ 0, 0 }, sf::Color::Transparent);
+	gradient[1] = sf::Vertex({ midX, 0 }, COLOR_BUTTON_BG_BLACK);
+	gradient[2] = sf::Vertex({ midX, dim.y }, COLOR_BUTTON_BG_BLACK);
+	gradient[3] = sf::Vertex({ 0, dim.y }, sf::Color::Transparent);
 
 	// right half
-	gradient[4] = sf::Vertex({ midX, 0.F }, COLOR_BUTTON_BG_BLACK);
-	gradient[5] = sf::Vertex({ static_cast<float>(dim.x), 0.F }, sf::Color::Transparent);
-	gradient[6] = sf::Vertex({ static_cast<float>(dim.x), static_cast<float>(dim.y) }, sf::Color::Transparent);
-	gradient[7] = sf::Vertex({ midX, static_cast<float>(dim.y) }, COLOR_BUTTON_BG_BLACK);
+	gradient[4] = sf::Vertex({ midX, 0 }, COLOR_BUTTON_BG_BLACK);
+	gradient[5] = sf::Vertex({ dim.x, 0 }, sf::Color::Transparent);
+	gradient[6] = sf::Vertex({ dim.x, dim.y }, sf::Color::Transparent);
+	gradient[7] = sf::Vertex({ midX, dim.y }, COLOR_BUTTON_BG_BLACK);
 
 	// center button text
 	// to center vertically, we can't use local bounds, as the baselines on different buttons would not match.
 	// use a constant top offset instead
-	this->text.setPosition(std::round(dim.x - this->text.getLocalBounds().width) / 2,
+	this->text.setPosition(std::round((dim.x - this->text.getLocalBounds().width) / 2),
 						   std::round((dim.y / 2) - (SettingsManager::guiScale * BTN_TEXT_TOP_OFFSET)));
 }
 

--- a/src/hud/color_selector.cpp
+++ b/src/hud/color_selector.cpp
@@ -7,6 +7,7 @@
 #include "../settings/settings_manager.hpp"
 #include "../util/util.hpp"
 #include "clickable.hpp"
+#include "sliders/slider_consts.hpp"
 
 const sf::Vector2f POS_2ND_LABEL(0, 25);
 const sf::Vector2f POS_3RD_LABEL(0, 50);

--- a/src/hud/color_selector.cpp
+++ b/src/hud/color_selector.cpp
@@ -21,9 +21,9 @@ const sf::Vector2f SIZE_COLOR_PREVIEW(65, 65);
 constexpr float COLOR_PREVIEW_OUTLINE_THICKNESS = 1;
 
 ColorSelector::ColorSelector(const sf::Font& font, sf::Color initialColor) :
-	sliderR(SLIDER_HORIZONTAL, font, true, 0, initialColor.r, COLOR_MAX_CHANNEL_VALUE),
-	sliderG(SLIDER_HORIZONTAL, font, true, 0, initialColor.g, COLOR_MAX_CHANNEL_VALUE),
-	sliderB(SLIDER_HORIZONTAL, font, true, 0, initialColor.b, COLOR_MAX_CHANNEL_VALUE)
+	sliderR(SLIDER_HORIZONTAL, INPUT_SLIDER_LENGTH, font, true, 0, initialColor.r, COLOR_MAX_CHANNEL_VALUE),
+	sliderG(SLIDER_HORIZONTAL, INPUT_SLIDER_LENGTH, font, true, 0, initialColor.g, COLOR_MAX_CHANNEL_VALUE),
+	sliderB(SLIDER_HORIZONTAL, INPUT_SLIDER_LENGTH, font, true, 0, initialColor.b, COLOR_MAX_CHANNEL_VALUE)
 {
 	this->labelR.setFillColor(sf::Color::Red);
 	this->labelG.setFillColor(sf::Color::Green);

--- a/src/hud/color_selector.cpp
+++ b/src/hud/color_selector.cpp
@@ -10,7 +10,7 @@
 
 const sf::Vector2f POS_2ND_LABEL(0, 25);
 const sf::Vector2f POS_3RD_LABEL(0, 50);
-const sf::Vector2f SIZE_LABEL(SLIDER_HANDLE_HEIGHT, SLIDER_HANDLE_HEIGHT);
+const sf::Vector2f SIZE_LABEL(SLIDER_HANDLE_THICKNESS, SLIDER_HANDLE_THICKNESS);
 
 const sf::Vector2f POS_1ST_SLIDER(20, 0);
 const sf::Vector2f POS_2ND_SLIDER(20, 25);
@@ -21,9 +21,9 @@ const sf::Vector2f SIZE_COLOR_PREVIEW(65, 65);
 constexpr float COLOR_PREVIEW_OUTLINE_THICKNESS = 1;
 
 ColorSelector::ColorSelector(const sf::Font& font, sf::Color initialColor) :
-	sliderR(font, true, 0, initialColor.r, COLOR_MAX_CHANNEL_VALUE),
-	sliderG(font, true, 0, initialColor.g, COLOR_MAX_CHANNEL_VALUE),
-	sliderB(font, true, 0, initialColor.b, COLOR_MAX_CHANNEL_VALUE)
+	sliderR(SLIDER_HORIZONTAL, font, true, 0, initialColor.r, COLOR_MAX_CHANNEL_VALUE),
+	sliderG(SLIDER_HORIZONTAL, font, true, 0, initialColor.g, COLOR_MAX_CHANNEL_VALUE),
+	sliderB(SLIDER_HORIZONTAL, font, true, 0, initialColor.b, COLOR_MAX_CHANNEL_VALUE)
 {
 	this->labelR.setFillColor(sf::Color::Red);
 	this->labelG.setFillColor(sf::Color::Green);

--- a/src/hud/color_selector.cpp
+++ b/src/hud/color_selector.cpp
@@ -21,9 +21,9 @@ const sf::Vector2f SIZE_COLOR_PREVIEW(65, 65);
 constexpr float COLOR_PREVIEW_OUTLINE_THICKNESS = 1;
 
 ColorSelector::ColorSelector(const sf::Font& font, sf::Color initialColor) :
-	sliderR(font, 0, initialColor.r, COLOR_MAX_CHANNEL_VALUE),
-	sliderG(font, 0, initialColor.g, COLOR_MAX_CHANNEL_VALUE),
-	sliderB(font, 0, initialColor.b, COLOR_MAX_CHANNEL_VALUE)
+	sliderR(font, true, 0, initialColor.r, COLOR_MAX_CHANNEL_VALUE),
+	sliderG(font, true, 0, initialColor.g, COLOR_MAX_CHANNEL_VALUE),
+	sliderB(font, true, 0, initialColor.b, COLOR_MAX_CHANNEL_VALUE)
 {
 	this->labelR.setFillColor(sf::Color::Red);
 	this->labelG.setFillColor(sf::Color::Green);

--- a/src/hud/log.cpp
+++ b/src/hud/log.cpp
@@ -20,7 +20,7 @@ std::list<LogElementText> Log::hudHistory;
 sf::Clock Log::clock;
 
 std::ofstream Log::logFile;
-std::function<void(const std::string& text, const sf::Color& color)> Log::msgAddedCallback = nullptr;
+msg_add_function Log::msgAddedCallback = nullptr;
 
 /**
  * Sets *temporary* SettingsManager settings, which are relevant only in the short window of time between when

--- a/src/hud/log.cpp
+++ b/src/hud/log.cpp
@@ -20,6 +20,7 @@ std::list<LogElementText> Log::hudHistory;
 sf::Clock Log::clock;
 
 std::ofstream Log::logFile;
+std::function<void(const std::string& text, const sf::Color& color)> Log::msgAddedCallback = nullptr;
 
 /**
  * Sets *temporary* SettingsManager settings, which are relevant only in the short window of time between when
@@ -38,6 +39,11 @@ void Log::setup()
 void Log::setFont(sf::Font* font)
 {
 	Log::font = font;
+}
+
+void Log::setMsgAddedCallback(const msg_add_function& callback)
+{
+	Log::msgAddedCallback = callback;
 }
 
 void Log::handleScreenResize(sf::Vector2u windowSize)

--- a/src/hud/log.cpp
+++ b/src/hud/log.cpp
@@ -16,7 +16,7 @@ sf::Vector2u Log::windowSize;
 
 uint Log::fontGap;
 
-std::list<std::unique_ptr<LogElementText>> Log::hudHistory;
+std::list<LogElementText> Log::hudHistory;
 sf::Clock Log::clock;
 
 std::ofstream Log::logFile;
@@ -48,9 +48,9 @@ void Log::handleScreenResize(sf::Vector2u windowSize)
 void Log::handleSettingsChange()
 {
 	Log::fontGap = Log::font->getLineSpacing(static_cast<uint>(SettingsManager::guiScale * FONT_H3));
-	for (const auto& item : Log::hudHistory)
+	for (auto& item : Log::hudHistory)
 	{
-		item->handleSettingsChange();
+		item.handleSettingsChange();
 	}
 }
 
@@ -83,7 +83,7 @@ void Log::tick(bool force)
 		return;
 
 	// remove items which were in the log for longer than LOG_ELEMENT_LIFE_TIME_S
-	Log::hudHistory.remove_if([](const auto& item) { return item->isTimeUp(); });
+	Log::hudHistory.remove_if([](const auto& item) { return item.isTimeUp(); });
 
 	// initial offset from top/bottom
 	if (SettingsManager::logAnchor == CORNER_BOTTOM_LEFT || SettingsManager::logAnchor == CORNER_BOTTOM_RIGHT)
@@ -93,9 +93,9 @@ void Log::tick(bool force)
 	for (auto& item : Log::hudHistory)
 	{
 		if (SettingsManager::logAnchor == CORNER_TOP_RIGHT || SettingsManager::logAnchor == CORNER_BOTTOM_RIGHT)
-			x = Log::windowSize.x - static_cast<uint>(item->getLocalBounds().width) - LOG_ANCHOR_NEG_PADDING_RIGHT;
+			x = Log::windowSize.x - static_cast<uint>(item.getLocalBounds().width) - LOG_ANCHOR_NEG_PADDING_RIGHT;
 
-		item->setPosition(static_cast<float>(x), static_cast<float>(y));
+		item.setPosition(static_cast<float>(x), static_cast<float>(y));
 
 		y += Log::fontGap;
 	}
@@ -107,7 +107,7 @@ void Log::draw(sf::RenderTarget& target)
 {
 	for (const auto& item : Log::hudHistory)
 	{
-		target.draw(*item);
+		target.draw(item);
 	}
 }
 

--- a/src/hud/log.hpp
+++ b/src/hud/log.hpp
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2022-2023 h67ma <szycikm@gmail.com>
+// (c) 2022-2024 h67ma <szycikm@gmail.com>
 
 #pragma once
 
 #include <fstream>
 #include <iostream>
 #include <list>
-#include <memory>
 #include <string>
 
 #include <SFML/Graphics/Color.hpp>
@@ -16,7 +15,6 @@
 #include <SFML/System/Clock.hpp>
 
 #include "../consts.hpp"
-#include "../hud/hud.hpp"
 #include "../settings/settings_manager.hpp"
 #include "../util/util.hpp"
 #include "log_element_text.hpp"
@@ -34,7 +32,7 @@ class Log
 		static sf::Vector2u windowSize;
 
 		static uint fontGap;
-		static std::list<std::unique_ptr<LogElementText>> hudHistory;
+		static std::list<LogElementText> hudHistory;
 		static sf::Clock clock;
 		static std::ofstream logFile;
 		static void logToFile(const char* prefix, const std::string& msg);
@@ -76,7 +74,7 @@ class Log
 			if (hideInGui || Log::font == nullptr)
 				return;
 
-			Log::hudHistory.emplace_back(std::make_unique<LogElementText>(formatted, *Log::font, color));
+			Log::hudHistory.emplace_back(formatted, *Log::font, color);
 			Log::tick(true);
 		}
 

--- a/src/hud/log.hpp
+++ b/src/hud/log.hpp
@@ -26,7 +26,7 @@
 #define LOG_PREFIX_DEBUG "[DEBG] "
 #define LOG_PREFIX_VERBOSE "[VERB] "
 
-using msg_add_function = std::function<void(const std::string&, const sf::Color&)>;
+using msg_add_function = std::function<void(const StringAndColor&)>;
 
 class Log
 {
@@ -86,7 +86,7 @@ class Log
 			}
 
 			if (msgAddedCallback != nullptr)
-				msgAddedCallback(formatted, color);
+				msgAddedCallback({ formatted, color });
 		}
 
 		/**

--- a/src/hud/log_element_text.cpp
+++ b/src/hud/log_element_text.cpp
@@ -11,15 +11,12 @@
 
 constexpr float LOG_ELEMENT_LIFE_TIME_S = 5;
 
-LogElementText::LogElementText(const std::string& text, sf::Font& font, const sf::Color& color) :
+LogElementText::LogElementText(const std::string& text, const sf::Font& font, const sf::Color& color) :
 	TextLabel(text, font, FONT_H3, color)
 {
-	this->setString(text);
-	this->setFont(font);
-	this->setFillColor(color);
 }
 
-bool LogElementText::isTimeUp()
+bool LogElementText::isTimeUp() const
 {
 	return this->clock.getElapsedTime().asSeconds() > LOG_ELEMENT_LIFE_TIME_S;
 }

--- a/src/hud/log_element_text.hpp
+++ b/src/hud/log_element_text.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2022-2023 h67ma <szycikm@gmail.com>
+// (c) 2022-2024 h67ma <szycikm@gmail.com>
 
 #pragma once
 
@@ -17,6 +17,6 @@ class LogElementText : public TextLabel
 		sf::Clock clock;
 
 	public:
-		LogElementText(const std::string& text, sf::Font& font, const sf::Color& color);
-		bool isTimeUp();
+		LogElementText(const std::string& text, const sf::Font& font, const sf::Color& color);
+		bool isTimeUp() const;
 };

--- a/src/hud/pages/gui_page.hpp
+++ b/src/hud/pages/gui_page.hpp
@@ -15,12 +15,14 @@
 #include "../clickable.hpp"
 #include "../configurable_gui_component.hpp"
 #include "../gui_transformable.hpp"
+#include "../sliders/slider_consts.hpp"
 
 constexpr uint POS_PAGE_BTNS_Y = 565;
 static const sf::Vector2u POS_PAGE_BTN_BOTTOM_1(0, POS_PAGE_BTNS_Y);
 static const sf::Vector2u POS_PAGE_BTN_BOTTOM_2(200, POS_PAGE_BTNS_Y);
 
 constexpr float FULL_PAGE_WIDTH = 1024;
+constexpr float FULL_PAGE_WIDTH_SANS_SCROLLBAR = FULL_PAGE_WIDTH - SLIDER_HANDLE_THICKNESS;
 constexpr float FULL_PAGE_HEIGHT = 596;
 
 /**

--- a/src/hud/pages/gui_page.hpp
+++ b/src/hud/pages/gui_page.hpp
@@ -20,6 +20,9 @@ constexpr uint POS_PAGE_BTNS_Y = 565;
 static const sf::Vector2u POS_PAGE_BTN_BOTTOM_1(0, POS_PAGE_BTNS_Y);
 static const sf::Vector2u POS_PAGE_BTN_BOTTOM_2(200, POS_PAGE_BTNS_Y);
 
+constexpr float FULL_PAGE_WIDTH = 1024;
+constexpr float FULL_PAGE_HEIGHT = 596;
+
 /**
  * Represents an abstract page to display in GUI (e.g. "Settings") - either in PipBuck or in main menu.
  * TODO Might display additional elements outside PipBuck screen area (e.g. question mark button).
@@ -44,6 +47,7 @@ class GuiPage : public sf::Drawable, public GuiTransformable
 		};
 
 		virtual void handleLeftClickUp() {};
+		virtual void handleScroll(float delta, sf::Vector2i mousePos) {};
 		virtual bool handleMouseMove(sf::Vector2i mousePos)
 		{
 			return false;

--- a/src/hud/pages/gui_page.hpp
+++ b/src/hud/pages/gui_page.hpp
@@ -12,6 +12,7 @@
 
 #include "../../campaigns/campaign.hpp"
 #include "../../consts.hpp"
+#include "../buttons/button_consts.hpp"
 #include "../clickable.hpp"
 #include "../configurable_gui_component.hpp"
 #include "../gui_transformable.hpp"
@@ -24,6 +25,7 @@ static const sf::Vector2u POS_PAGE_BTN_BOTTOM_2(200, POS_PAGE_BTNS_Y);
 constexpr float FULL_PAGE_WIDTH = 1024;
 constexpr float FULL_PAGE_WIDTH_SANS_SCROLLBAR = FULL_PAGE_WIDTH - SLIDER_HANDLE_THICKNESS;
 constexpr float FULL_PAGE_HEIGHT = 596;
+constexpr float FULL_PAGE_HEIGHT_SANS_BOTTOM_BTNS = FULL_PAGE_HEIGHT - BTN_SIMPLE_NORMAL_HEIGHT - 10;
 
 /**
  * Represents an abstract page to display in GUI (e.g. "Settings") - either in PipBuck or in main menu.

--- a/src/hud/pages/gui_page_controls.cpp
+++ b/src/hud/pages/gui_page_controls.cpp
@@ -44,7 +44,7 @@ void GuiPageControls::updateDisplay()
 									SettingsManager::hudColor);
 	}
 
-	this->mappingDump.handleItemsChanged();
+	this->mappingDump.handleItemsChanged(SCROLL_TOP);
 }
 
 bool GuiPageControls::handleMouseMove(sf::Vector2i mousePos)

--- a/src/hud/pages/gui_page_controls.cpp
+++ b/src/hud/pages/gui_page_controls.cpp
@@ -22,7 +22,8 @@ GuiPageControls::GuiPageControls(ResourceManager& resMgr) :
 					Log::i(STR_KEYMAP_RESETTED);
 					Keymap::save();
 				} } }),
-	dummyMapDump(*resMgr.getFont(FONT_NORMAL), 17U, { 0.F, 0.F })
+	mappingDump(resMgr, FONT_FIXED, FONT_H3, { FULL_PAGE_WIDTH_SANS_SCROLLBAR, FULL_PAGE_HEIGHT_SANS_BOTTOM_BTNS },
+				this->dumpList)
 {
 	for (auto& btn : this->buttons)
 	{
@@ -35,29 +36,48 @@ GuiPageControls::GuiPageControls(ResourceManager& resMgr) :
 
 void GuiPageControls::updateDisplay()
 {
-	// for now only dump the current mapping as text. TODO proper scrollable table
-	std::string dump("");
-
+	this->dumpList.clear();
 	for (const auto item : Keymap::getKeyToActionMap())
 	{
-		dump += Keymap::actionToDisplayString(item.second) + " -> " + Keymap::keyToString(item.first) + '\n';
+		this->dumpList.emplace_back(Keymap::actionToDisplayString(item.second) + " -> " +
+										Keymap::keyToString(item.first),
+									SettingsManager::hudColor);
 	}
 
-	this->dummyMapDump.setString(dump);
+	this->mappingDump.handleItemsChanged();
 }
 
 bool GuiPageControls::handleMouseMove(sf::Vector2i mousePos)
 {
 	mousePos -= this->getPosition();
 
-	return this->hoverMgr.handleMouseMove(mousePos);
+	if (this->hoverMgr.handleMouseMove(mousePos))
+		return true;
+
+	return this->mappingDump.handleMouseMove(mousePos);
 }
 
 ClickStatus GuiPageControls::handleLeftClick(sf::Vector2i clickPos)
 {
 	clickPos -= this->getPosition();
 
-	return this->clickMgr.handleLeftClick(clickPos);
+	ClickStatus status = this->clickMgr.handleLeftClick(clickPos);
+	if (status != CLICK_NOT_CONSUMED)
+		return status;
+
+	return this->mappingDump.handleLeftClick(clickPos);
+}
+
+void GuiPageControls::handleLeftClickUp()
+{
+	this->mappingDump.handleLeftClickUp();
+}
+
+void GuiPageControls::handleScroll(float delta, sf::Vector2i mousePos)
+{
+	mousePos -= this->getPosition();
+
+	this->mappingDump.handleScroll(delta, mousePos);
 }
 
 void GuiPageControls::handleSettingsChange()
@@ -69,7 +89,7 @@ void GuiPageControls::handleSettingsChange()
 		btn.handleSettingsChange();
 	}
 
-	this->dummyMapDump.handleSettingsChange();
+	this->mappingDump.handleSettingsChange();
 }
 
 void GuiPageControls::draw(sf::RenderTarget& target, sf::RenderStates states) const
@@ -81,5 +101,5 @@ void GuiPageControls::draw(sf::RenderTarget& target, sf::RenderStates states) co
 		target.draw(btn, states);
 	}
 
-	target.draw(this->dummyMapDump, states);
+	target.draw(this->mappingDump, states);
 }

--- a/src/hud/pages/gui_page_controls.hpp
+++ b/src/hud/pages/gui_page_controls.hpp
@@ -11,7 +11,7 @@
 #include "../buttons/simple_button.hpp"
 #include "../click_manager.hpp"
 #include "../hover_manager.hpp"
-#include "../wrappable_text.hpp"
+#include "../scrollable/text_list_view.hpp"
 #include "gui_page.hpp"
 
 /**
@@ -24,13 +24,16 @@ class GuiPageControls : public GuiPage
 		std::vector<SimpleButton> buttons;
 		HoverManager hoverMgr;
 		ClickManager clickMgr;
-		WrappableText dummyMapDump; // TODO delet this
+		std::deque<StringAndColor> dumpList;
+		TextListView mappingDump; // TODO allow changing keybinds
 		void updateDisplay();
 
 	public:
 		explicit GuiPageControls(ResourceManager& resMgr);
 		bool handleMouseMove(sf::Vector2i mousePos) override;
 		ClickStatus handleLeftClick(sf::Vector2i clickPos) override;
+		void handleLeftClickUp() override;
+		void handleScroll(float delta, sf::Vector2i mousePos) override;
 		void handleSettingsChange() override;
 		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 };

--- a/src/hud/pages/gui_page_log.cpp
+++ b/src/hud/pages/gui_page_log.cpp
@@ -41,6 +41,25 @@ void GuiPageLog::handleSettingsChange()
 	this->logListView.handleSettingsChange();
 }
 
+ClickStatus GuiPageLog::handleLeftClick(sf::Vector2i clickPos)
+{
+	clickPos -= this->getPosition();
+
+	return this->logListView.handleLeftClick(clickPos);
+}
+
+void GuiPageLog::handleLeftClickUp()
+{
+	this->logListView.handleLeftClickUp();
+}
+
+bool GuiPageLog::handleMouseMove(sf::Vector2i mousePos)
+{
+	mousePos -= this->getPosition();
+
+	return this->logListView.handleMouseMove(mousePos);
+}
+
 void GuiPageLog::draw(sf::RenderTarget& target, sf::RenderStates states) const
 {
 	states.transform *= this->getTransform();

--- a/src/hud/pages/gui_page_log.cpp
+++ b/src/hud/pages/gui_page_log.cpp
@@ -16,12 +16,12 @@ GuiPageLog::GuiPageLog(ResourceManager& resMgr) :
 {
 }
 
-void GuiPageLog::addMsg(const std::string& text, const sf::Color& color)
+void GuiPageLog::addMsg(const StringAndColor& strAndColor)
 {
 	// obviously a temporary solution. should be a scrollable list.
 	sf::Vector2f position = sf::Vector2f(20, 20 + (this->msgList.size() * 30));
 
-	this->msgList.emplace_back(text, *resMgr.getFont(FONT_NORMAL), FONT_H3, color, position);
+	this->msgList.emplace_back(strAndColor.first, *resMgr.getFont(FONT_NORMAL), FONT_H3, strAndColor.second, position);
 
 	// remove oldest message if limit is reached
 	if (this->msgList.size() > LOG_HISTORY_MAX_LENGTH)

--- a/src/hud/pages/gui_page_log.cpp
+++ b/src/hud/pages/gui_page_log.cpp
@@ -12,28 +12,38 @@ constexpr uint LOG_HISTORY_MAX_LENGTH = 1000; // TODO? make configurable via set
 
 GuiPageLog::GuiPageLog(ResourceManager& resMgr) :
 	GuiPage("Log"), // TODO translate
-	resMgr(resMgr)
+	logListView(resMgr, FONT_NORMAL, FONT_SPAN, { FULL_PAGE_WIDTH, FULL_PAGE_HEIGHT }, this->msgList)
 {
 }
 
 void GuiPageLog::addMsg(const StringAndColor& strAndColor)
 {
-	// obviously a temporary solution. should be a scrollable list.
-	sf::Vector2f position = sf::Vector2f(20, 20 + (this->msgList.size() * 30));
-
-	this->msgList.emplace_back(strAndColor.first, *resMgr.getFont(FONT_NORMAL), FONT_H3, strAndColor.second, position);
+	this->msgList.emplace_back(strAndColor);
 
 	// remove oldest message if limit is reached
 	if (this->msgList.size() > LOG_HISTORY_MAX_LENGTH)
 		this->msgList.pop_front();
+
+	this->logListView.handleItemsChanged();
+}
+
+void GuiPageLog::handleScroll(float delta, sf::Vector2i mousePos)
+{
+	mousePos -= this->getPosition();
+
+	this->logListView.handleScroll(delta, mousePos);
+}
+
+void GuiPageLog::handleSettingsChange()
+{
+	GuiPage::handleSettingsChange();
+
+	this->logListView.handleSettingsChange();
 }
 
 void GuiPageLog::draw(sf::RenderTarget& target, sf::RenderStates states) const
 {
 	states.transform *= this->getTransform();
 
-	for (const auto& msg : this->msgList)
-	{
-		target.draw(msg, states);
-	}
+	target.draw(this->logListView, states);
 }

--- a/src/hud/pages/gui_page_log.cpp
+++ b/src/hud/pages/gui_page_log.cpp
@@ -12,7 +12,7 @@ constexpr uint LOG_HISTORY_MAX_LENGTH = 1000; // TODO? make configurable via set
 
 GuiPageLog::GuiPageLog(ResourceManager& resMgr) :
 	GuiPage("Log"), // TODO translate
-	logListView(resMgr, FONT_NORMAL, FONT_SPAN, { FULL_PAGE_WIDTH, FULL_PAGE_HEIGHT }, this->msgList)
+	logListView(resMgr, FONT_NORMAL, FONT_SPAN, { FULL_PAGE_WIDTH_SANS_SCROLLBAR, FULL_PAGE_HEIGHT }, this->msgList)
 {
 }
 

--- a/src/hud/pages/gui_page_log.cpp
+++ b/src/hud/pages/gui_page_log.cpp
@@ -6,16 +6,34 @@
 
 #include <string>
 
-GuiPageLog::GuiPageLog(ResourceManager& resMgr) : GuiPage("Log") // TODO translate
+#include "../hud.hpp"
+
+constexpr uint LOG_HISTORY_MAX_LENGTH = 1000; // TODO? make configurable via settings
+
+GuiPageLog::GuiPageLog(ResourceManager& resMgr) :
+	GuiPage("Log"), // TODO translate
+	resMgr(resMgr)
 {
-	this->dummy.setFont(*resMgr.getFont(FONT_FIXED));
-	this->dummy.setPosition(100.F, 250.F);
-	this->dummy.setString("log");
+}
+
+void GuiPageLog::addMsg(const std::string& text, const sf::Color& color)
+{
+	// obviously a temporary solution. should be a scrollable list.
+	sf::Vector2f position = sf::Vector2f(20, 20 + (this->msgList.size() * 30));
+
+	this->msgList.emplace_back(text, *resMgr.getFont(FONT_NORMAL), FONT_H3, color, position);
+
+	// remove oldest message if limit is reached
+	if (this->msgList.size() > LOG_HISTORY_MAX_LENGTH)
+		this->msgList.pop_front();
 }
 
 void GuiPageLog::draw(sf::RenderTarget& target, sf::RenderStates states) const
 {
 	states.transform *= this->getTransform();
 
-	target.draw(this->dummy, states);
+	for (const auto& msg : this->msgList)
+	{
+		target.draw(msg, states);
+	}
 }

--- a/src/hud/pages/gui_page_log.cpp
+++ b/src/hud/pages/gui_page_log.cpp
@@ -24,7 +24,7 @@ void GuiPageLog::addMsg(const StringAndColor& strAndColor)
 	if (this->msgList.size() > LOG_HISTORY_MAX_LENGTH)
 		this->msgList.pop_front();
 
-	this->logListView.handleItemsChanged();
+	this->logListView.handleItemsChanged(SCROLL_BOTTOM);
 }
 
 void GuiPageLog::handleScroll(float delta, sf::Vector2i mousePos)

--- a/src/hud/pages/gui_page_log.hpp
+++ b/src/hud/pages/gui_page_log.hpp
@@ -9,7 +9,7 @@
 
 #include "../../consts.hpp"
 #include "../../resources/resource_manager.hpp"
-#include "../text_label.hpp"
+#include "../scrollable/text_list_view.hpp"
 #include "gui_page.hpp"
 
 /**
@@ -18,11 +18,13 @@
 class GuiPageLog : public GuiPage
 {
 	private:
-		std::deque<TextLabel> msgList;
-		ResourceManager& resMgr;
+		std::deque<StringAndColor> msgList;
+		TextListView logListView;
 
 	public:
 		explicit GuiPageLog(ResourceManager& resMgr);
 		void addMsg(const StringAndColor& strAndColor);
+		void handleScroll(float delta, sf::Vector2i mousePos) override;
+		void handleSettingsChange() override;
 		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 };

--- a/src/hud/pages/gui_page_log.hpp
+++ b/src/hud/pages/gui_page_log.hpp
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include <deque>
 #include <string>
 
 #include "../../resources/resource_manager.hpp"
+#include "../text_label.hpp"
 #include "gui_page.hpp"
 
 /**
@@ -14,7 +16,12 @@
  */
 class GuiPageLog : public GuiPage
 {
+	private:
+		std::deque<TextLabel> msgList;
+		ResourceManager& resMgr;
+
 	public:
 		explicit GuiPageLog(ResourceManager& resMgr);
+		void addMsg(const std::string& text, const sf::Color& color);
 		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 };

--- a/src/hud/pages/gui_page_log.hpp
+++ b/src/hud/pages/gui_page_log.hpp
@@ -26,5 +26,8 @@ class GuiPageLog : public GuiPage
 		void addMsg(const StringAndColor& strAndColor);
 		void handleScroll(float delta, sf::Vector2i mousePos) override;
 		void handleSettingsChange() override;
+		ClickStatus handleLeftClick(sf::Vector2i clickPos) override;
+		void handleLeftClickUp() override;
+		bool handleMouseMove(sf::Vector2i mousePos) override;
 		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 };

--- a/src/hud/pages/gui_page_log.hpp
+++ b/src/hud/pages/gui_page_log.hpp
@@ -7,6 +7,7 @@
 #include <deque>
 #include <string>
 
+#include "../../consts.hpp"
 #include "../../resources/resource_manager.hpp"
 #include "../text_label.hpp"
 #include "gui_page.hpp"
@@ -22,6 +23,6 @@ class GuiPageLog : public GuiPage
 
 	public:
 		explicit GuiPageLog(ResourceManager& resMgr);
-		void addMsg(const std::string& text, const sf::Color& color);
+		void addMsg(const StringAndColor& strAndColor);
 		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 };

--- a/src/hud/pages/gui_page_settings.cpp
+++ b/src/hud/pages/gui_page_settings.cpp
@@ -33,7 +33,7 @@ GuiPageSettings::GuiPageSettings(ResourceManager& resMgr) :
 				},
 				CLICK_CONSUMED_SETTINGS_CHANGED } }),
 	hudColorSelector(*resMgr.getFont(FONT_NORMAL), SettingsManager::hudColor),
-	guiScaleSlider(SLIDER_HORIZONTAL, *resMgr.getFont(FONT_NORMAL), true, GUI_SCALE_MIN_VALUE,
+	guiScaleSlider(SLIDER_HORIZONTAL, INPUT_SLIDER_LENGTH, *resMgr.getFont(FONT_NORMAL), true, GUI_SCALE_MIN_VALUE,
 				   SettingsManager::guiScale, GUI_SCALE_MAX_VALUE, 2),
 	infoText(*resMgr.getFont(FONT_NORMAL), 17U, { 0.F, 22.F })
 {

--- a/src/hud/pages/gui_page_settings.cpp
+++ b/src/hud/pages/gui_page_settings.cpp
@@ -33,8 +33,8 @@ GuiPageSettings::GuiPageSettings(ResourceManager& resMgr) :
 				},
 				CLICK_CONSUMED_SETTINGS_CHANGED } }),
 	hudColorSelector(*resMgr.getFont(FONT_NORMAL), SettingsManager::hudColor),
-	guiScaleSlider(*resMgr.getFont(FONT_NORMAL), true, GUI_SCALE_MIN_VALUE, SettingsManager::guiScale,
-				   GUI_SCALE_MAX_VALUE, 2),
+	guiScaleSlider(SLIDER_HORIZONTAL, *resMgr.getFont(FONT_NORMAL), true, GUI_SCALE_MIN_VALUE,
+				   SettingsManager::guiScale, GUI_SCALE_MAX_VALUE, 2),
 	infoText(*resMgr.getFont(FONT_NORMAL), 17U, { 0.F, 22.F })
 {
 	for (auto& btn : this->buttons)

--- a/src/hud/pages/gui_page_settings.cpp
+++ b/src/hud/pages/gui_page_settings.cpp
@@ -33,8 +33,8 @@ GuiPageSettings::GuiPageSettings(ResourceManager& resMgr) :
 				},
 				CLICK_CONSUMED_SETTINGS_CHANGED } }),
 	hudColorSelector(*resMgr.getFont(FONT_NORMAL), SettingsManager::hudColor),
-	guiScaleSlider(*resMgr.getFont(FONT_NORMAL), GUI_SCALE_MIN_VALUE, SettingsManager::guiScale, GUI_SCALE_MAX_VALUE,
-				   2),
+	guiScaleSlider(*resMgr.getFont(FONT_NORMAL), true, GUI_SCALE_MIN_VALUE, SettingsManager::guiScale,
+				   GUI_SCALE_MAX_VALUE, 2),
 	infoText(*resMgr.getFont(FONT_NORMAL), 17U, { 0.F, 22.F })
 {
 	for (auto& btn : this->buttons)

--- a/src/hud/pipbuck/pipbuck.cpp
+++ b/src/hud/pipbuck/pipbuck.cpp
@@ -316,6 +316,16 @@ void PipBuck::handleLeftClickUp()
 		this->selectedCategory->handleLeftClickUp();
 }
 
+void PipBuck::handleScroll(float delta, sf::Vector2i mousePos)
+{
+	if (this->selectedCategory != nullptr)
+	{
+		mousePos -= this->getPosition();
+
+		this->selectedCategory->handleScroll(delta, mousePos);
+	}
+}
+
 void PipBuck::handleMouseMove(sf::Vector2i mousePos)
 {
 	if (this->selectedCategory == nullptr)

--- a/src/hud/pipbuck/pipbuck.cpp
+++ b/src/hud/pipbuck/pipbuck.cpp
@@ -351,6 +351,22 @@ bool PipBuck::setupCampaignInfos()
 	return true;
 }
 
+/**
+ * Adds a log message to the Log PipBuck page.
+ */
+void PipBuck::addLogMessage(const std::string& text, const sf::Color& color)
+{
+	auto foundCat = this->categories.find(PIPB_CAT_GAME);
+	if (foundCat == this->categories.end())
+		return;
+
+	auto* logPage = foundCat->second->getPage<GuiPageLog>(PIPB_PAGE_LOG);
+	if (logPage == nullptr)
+		return;
+
+	logPage->addMsg(text, color);
+}
+
 void PipBuck::unloadCampaignInfos()
 {
 	Log::d(STR_PIPBUCK_UNLOADING_CAMPAIGN);

--- a/src/hud/pipbuck/pipbuck.cpp
+++ b/src/hud/pipbuck/pipbuck.cpp
@@ -354,7 +354,7 @@ bool PipBuck::setupCampaignInfos()
 /**
  * Adds a log message to the Log PipBuck page.
  */
-void PipBuck::addLogMessage(const std::string& text, const sf::Color& color)
+void PipBuck::addLogMessage(const StringAndColor& strAndColor)
 {
 	auto foundCat = this->categories.find(PIPB_CAT_GAME);
 	if (foundCat == this->categories.end())
@@ -364,7 +364,7 @@ void PipBuck::addLogMessage(const std::string& text, const sf::Color& color)
 	if (logPage == nullptr)
 		return;
 
-	logPage->addMsg(text, color);
+	logPage->addMsg(strAndColor);
 }
 
 void PipBuck::unloadCampaignInfos()

--- a/src/hud/pipbuck/pipbuck.hpp
+++ b/src/hud/pipbuck/pipbuck.hpp
@@ -87,6 +87,7 @@ class PipBuck : public sf::Drawable, public sf::Transformable, public Configurab
 		void handleScreenResize(sf::Vector2u windowSize);
 		ClickStatus handleLeftClick(sf::Vector2i clickPos);
 		void handleLeftClickUp();
+		void handleScroll(float delta, sf::Vector2i mousePos);
 		void handleMouseMove(sf::Vector2i mousePos);
 		bool setupCampaignInfos();
 		void addLogMessage(const StringAndColor& strAndColor);

--- a/src/hud/pipbuck/pipbuck.hpp
+++ b/src/hud/pipbuck/pipbuck.hpp
@@ -14,6 +14,7 @@
 #include <SFML/System/Clock.hpp>
 
 #include "../../campaigns/campaign.hpp"
+#include "../../consts.hpp"
 #include "../../resources/resource_manager.hpp"
 #include "../../resources/sound_resource.hpp"
 #include "../../resources/sprite_resource.hpp"
@@ -88,7 +89,7 @@ class PipBuck : public sf::Drawable, public sf::Transformable, public Configurab
 		void handleLeftClickUp();
 		void handleMouseMove(sf::Vector2i mousePos);
 		bool setupCampaignInfos();
-		void addLogMessage(const std::string& text, const sf::Color& color);
+		void addLogMessage(const StringAndColor& strAndColor);
 		void unloadCampaignInfos();
 		void open(sf::Vector2i mousePos, bool sound = true);
 		bool switchToPage(PipBuckPageType pageType, sf::Vector2i mousePos);

--- a/src/hud/pipbuck/pipbuck.hpp
+++ b/src/hud/pipbuck/pipbuck.hpp
@@ -88,6 +88,7 @@ class PipBuck : public sf::Drawable, public sf::Transformable, public Configurab
 		void handleLeftClickUp();
 		void handleMouseMove(sf::Vector2i mousePos);
 		bool setupCampaignInfos();
+		void addLogMessage(const std::string& text, const sf::Color& color);
 		void unloadCampaignInfos();
 		void open(sf::Vector2i mousePos, bool sound = true);
 		bool switchToPage(PipBuckPageType pageType, sf::Vector2i mousePos);

--- a/src/hud/pipbuck/pipbuck_category.cpp
+++ b/src/hud/pipbuck/pipbuck_category.cpp
@@ -141,6 +141,16 @@ void PipBuckCategory::handleLeftClickUp()
 		this->selectedPage->handleLeftClickUp();
 }
 
+void PipBuckCategory::handleScroll(float delta, sf::Vector2i mousePos)
+{
+	if (this->selectedPage != nullptr)
+	{
+		mousePos -= this->getPosition();
+
+		this->selectedPage->handleScroll(delta, mousePos);
+	}
+}
+
 bool PipBuckCategory::handleMouseMove(sf::Vector2i mousePos)
 {
 	if (this->selectedPage == nullptr)

--- a/src/hud/pipbuck/pipbuck_category.hpp
+++ b/src/hud/pipbuck/pipbuck_category.hpp
@@ -54,6 +54,7 @@ class PipBuckCategory : public sf::Drawable, public sf::Transformable, public Co
 		PipBuckPageType getSelectedPageType() const;
 		ClickStatus handleLeftClick(sf::Vector2i clickPos);
 		void handleLeftClickUp();
+		void handleScroll(float delta, sf::Vector2i mousePos);
 		bool handleMouseMove(sf::Vector2i mousePos);
 		bool changePage(PipBuckPageType newPageType);
 		bool setupCampaignInfos();

--- a/src/hud/pipbuck/pipbuck_category.hpp
+++ b/src/hud/pipbuck/pipbuck_category.hpp
@@ -61,4 +61,19 @@ class PipBuckCategory : public sf::Drawable, public sf::Transformable, public Co
 		static PipBuckCategoryType pageTypeToCategoryType(PipBuckPageType pageType);
 		void handleSettingsChange() override;
 		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
+
+		/**
+		 * Finds a page and casts it to specific type.
+		 * Return value can be a nullptr if page was not found or if the cast failed.
+		 */
+		template<typename T>
+		T* getPage(PipBuckPageType type) const
+		{
+			auto foundPage = this->pages.find(type);
+			if (foundPage == this->pages.end())
+				return nullptr;
+
+			// dynamic_pointer_cast with template type is C++20
+			return dynamic_cast<T*>(foundPage->second.get());
+		}
 };

--- a/src/hud/scrollable/list_view.hpp
+++ b/src/hud/scrollable/list_view.hpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// (c) 2024 h67ma <szycikm@gmail.com>
+
+#pragma once
+
+#include <stdexcept>
+
+#include <SFML/System/Vector2.hpp>
+
+#include "../../util/util.hpp"
+#include "../clickable.hpp"
+#include "../hud.hpp"
+#include "scrollable.hpp"
+
+/**
+ * A generic scrollable component, displaying a vertically stacked collection of items. All items are the same type of
+ * component (can be a text label, image, table row, etc.).
+ *
+ * Items are displayed based on data (@tparam Data) stored in a collection (@tparam Container). Note that a view holder
+ * (@tparam Holder) component is *not* created for each data item in the collection. Instead, one view holder is being
+ * reused to draw all items.
+ *
+ * @tparam Holder component used to display a single item
+ * @tparam Data struct/class holding a single item's data
+ * @tparam Container implementation of the collection which stores data items
+ */
+template<typename Holder, typename Data, template<typename, typename> class Container>
+class ListView : public Scrollable
+{
+	private:
+		const float itemHeight; // the height of a single item
+		Container<Data, std::allocator<Data>>& items;
+
+		void scrollableContentHeightChanged(bool resize)
+		{
+			float totalHeight = calculateGuiAwareScalar(this->itemHeight) * static_cast<float>(this->items.size());
+			this->handleScrollableContentHeightChanged(totalHeight, SCROLL_BOTTOM, resize);
+		}
+
+	protected:
+		virtual const Holder& bindViewHolder(const Data& item) = 0;
+
+	public:
+		ListView(const sf::Vector2f& scrollableAreaSize, float itemHeight,
+				 Container<Data, std::allocator<Data>>& items) :
+			Scrollable(scrollableAreaSize),
+			itemHeight(itemHeight),
+			items(items)
+		{
+		}
+
+		/**
+		 * Handles a click event on list. Finds the clicked item and returns it (via param).
+		 *
+		 * @param clickPos click position
+		 * @param clickedData output param containing the item's data, if an item was clicked. Otherwise unmodified
+		 * @returns CLICK_CONSUMED if an item was clicked, CLICK_NOT_CONSUMED otherwise
+		 */
+		ClickStatus handleLeftClick(sf::Vector2i clickPos, Data& clickedData)
+		{
+			clickPos -= this->getPosition();
+
+			if (!this->isWithinScrollArea(static_cast<sf::Vector2f>(clickPos)))
+				return CLICK_NOT_CONSUMED;
+
+			// click was inside the scroll area.
+			// find the selected item, assuming the item's width is equal to scroll area width.
+
+			std::size_t selectedItemIdx =
+				(-this->getScrollOffset() + clickPos.y) / calculateGuiAwareScalar(this->itemHeight);
+			try
+			{
+				clickedData = items.at(selectedItemIdx);
+			}
+			catch (const std::out_of_range& ex)
+			{
+				return CLICK_NOT_CONSUMED;
+			}
+
+			return CLICK_CONSUMED;
+		}
+
+		void handleItemsChanged()
+		{
+			this->scrollableContentHeightChanged(false);
+		}
+
+		void handleSettingsChange() override
+		{
+			Scrollable::handleSettingsChange();
+
+			this->scrollableContentHeightChanged(true);
+		}
+
+		/**
+		 * Draws the collection of items as vertical list.
+		 * Only draws items that are currently visible inside the scrollable area.
+		 */
+		void drawScrollableContent(sf::RenderTarget& target, sf::RenderStates states) override
+		{
+			float offset = 0; // sadly can't reuse the y offset from render states
+			float scaledItemHeight = calculateGuiAwareScalar(this->itemHeight);
+
+			for (const auto& item : this->items)
+			{
+				if (this->shouldDrawItem(scaledItemHeight, offset))
+					target.draw(this->bindViewHolder(item), states);
+
+				// move down regardless if the item was actually drawn or not,
+				// as the next item might qualify for drawing.
+				// this happens when the list is scrolled a bit.
+				offset += scaledItemHeight;
+				states.transform.translate(0, scaledItemHeight);
+			}
+		}
+};

--- a/src/hud/scrollable/list_view.hpp
+++ b/src/hud/scrollable/list_view.hpp
@@ -8,6 +8,7 @@
 
 #include <SFML/System/Vector2.hpp>
 
+#include "../../resources/resource_manager.hpp"
 #include "../../util/util.hpp"
 #include "../clickable.hpp"
 #include "../hud.hpp"
@@ -42,12 +43,20 @@ class ListView : public Scrollable
 		virtual const Holder& bindViewHolder(const Data& item) = 0;
 
 	public:
-		ListView(const sf::Vector2f& scrollableAreaSize, float itemHeight,
+		ListView(ResourceManager& resMgr, const sf::Vector2f& scrollableAreaSize, float itemHeight,
 				 Container<Data, std::allocator<Data>>& items) :
-			Scrollable(scrollableAreaSize),
+			Scrollable(resMgr, scrollableAreaSize),
 			itemHeight(itemHeight),
 			items(items)
 		{
+		}
+
+		/**
+		 * Click handler that does not support detecting clicks on items (only scrollbar).
+		 */
+		ClickStatus handleLeftClick(sf::Vector2i clickPos) override
+		{
+			return Scrollable::handleLeftClick(clickPos);
 		}
 
 		/**
@@ -60,6 +69,10 @@ class ListView : public Scrollable
 		ClickStatus handleLeftClick(sf::Vector2i clickPos, Data& clickedData)
 		{
 			clickPos -= this->getPosition();
+
+			ClickStatus status = Scrollable::handleLeftClick(clickPos);
+			if (status != CLICK_NOT_CONSUMED)
+				return status;
 
 			if (!this->isWithinScrollArea(static_cast<sf::Vector2f>(clickPos)))
 				return CLICK_NOT_CONSUMED;

--- a/src/hud/scrollable/list_view.hpp
+++ b/src/hud/scrollable/list_view.hpp
@@ -33,10 +33,10 @@ class ListView : public Scrollable
 		const float itemHeight; // the height of a single item
 		Container<Data, std::allocator<Data>>& items;
 
-		void scrollableContentHeightChanged(bool resize)
+		void scrollableContentHeightChanged(enum ScrollPosition scrollTo, bool resize)
 		{
 			float totalHeight = calculateGuiAwareScalar(this->itemHeight) * static_cast<float>(this->items.size());
-			this->handleScrollableContentHeightChanged(totalHeight, SCROLL_BOTTOM, resize);
+			this->handleScrollableContentHeightChanged(totalHeight, scrollTo, resize);
 		}
 
 	protected:
@@ -94,16 +94,16 @@ class ListView : public Scrollable
 			return CLICK_CONSUMED;
 		}
 
-		void handleItemsChanged()
+		void handleItemsChanged(enum ScrollPosition scrollTo)
 		{
-			this->scrollableContentHeightChanged(false);
+			this->scrollableContentHeightChanged(scrollTo, false);
 		}
 
 		void handleSettingsChange() override
 		{
 			Scrollable::handleSettingsChange();
 
-			this->scrollableContentHeightChanged(true);
+			this->scrollableContentHeightChanged(SCROLL_UNCHANGED, true);
 		}
 
 		/**

--- a/src/hud/scrollable/scrollable.cpp
+++ b/src/hud/scrollable/scrollable.cpp
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// (c) 2024 h67ma <szycikm@gmail.com>
+
+#include "scrollable.hpp"
+
+#include <memory>
+
+#include "../../util/util.hpp"
+#include "../hud.hpp"
+
+constexpr float SCROLL_FACTOR = 25; // TODO? make configurable in settings
+
+Scrollable::Scrollable(const sf::Vector2f& scrollableAreaSize) : scrollableAreaSize(scrollableAreaSize)
+{
+	this->setGuiScale();
+}
+
+/**
+ * Should be called immediately after object's creation (to initialize ::scrollableContentTexture)
+ */
+void Scrollable::setGuiScale()
+{
+	sf::Vector2f scaledSize = calculateGuiAwarePoint(this->scrollableAreaSize);
+
+	this->scrollArea.setSize(scaledSize);
+
+	// there's no resize, and it's hard to tell if calling ::create() multiple times leads to creating additional
+	// textures indefinitely - better to destroy it to be sure
+	this->scrollableContentTexture.reset(nullptr);
+	this->scrollableContentTexture = std::make_unique<sf::RenderTexture>();
+	this->scrollableContentTexture->create(static_cast<uint>(scaledSize.x), static_cast<uint>(scaledSize.y));
+}
+
+/**
+ * Renders scrollable content to a texture, which is later drawn in ::draw().
+ *
+ * @param resize whether the render texture is being resized
+ *
+ * The intermediate texture is required because content needs to be trimmed to scrollable area size.
+ * Note that a trimming mask (+ blend mode) is not required, as we're drawing to a rectangular texture, so contents
+ * drawn outside of its area will simply not be visible.
+ */
+void Scrollable::redrawScrollableContent(bool resize)
+{
+	sf::RenderStates states;
+
+	this->scrollableContentTexture->clear(sf::Color::Transparent);
+
+	// draw scrollable content at current scroll offset
+	states.transform.translate(0, this->scrollOffset);
+	this->drawScrollableContent(*this->scrollableContentTexture, states);
+
+	this->scrollableContentTexture->display();
+	this->scrollableContentSprite.setTexture(this->scrollableContentTexture->getTexture(), resize);
+}
+
+/**
+ * Update the total height of scrollable content.
+ *
+ * @param newHeight height of the resized content
+ * @param scrollTo where the content should be scrolled to
+ * @param resize whether the scrollable area is being resized
+ *
+ * Ensures the scroll range and position make sense after this change.
+ * Required for scroll limits and scroll bar to behave/display correctly.
+ */
+void Scrollable::handleScrollableContentHeightChanged(float newHeight, enum ScrollPosition scrollTo, bool resize)
+{
+	this->scrollableContentHeight = newHeight;
+
+	this->bottomScrollLimit = this->scrollArea.getSize().y - this->scrollableContentHeight;
+
+	// if the content got shorter than scroll area, scroll it to the top
+	if (scrollTo == SCROLL_TOP || this->scrollableContentHeight <= this->scrollArea.getSize().y)
+		this->scrollOffset = 0;
+	// if the content got shorter, but is still taller than scroll area, and was previously scrolled to the
+	// bottom, scroll it to the new bottom
+	else if (scrollTo == SCROLL_BOTTOM || this->scrollOffset < this->bottomScrollLimit)
+		this->scrollOffset = this->bottomScrollLimit;
+
+	// the content height changed, so the content itself also changed - redraw it
+	this->redrawScrollableContent(resize);
+}
+
+/**
+ * Checks if an item in scrollable area should be drawn or not.
+ * If its bounds lay entirely outside of the scroll area, then no sense drawing it.
+ * Note: only y axis is checked.
+ * Note: assumes the scroll area's y = 0.
+ */
+bool Scrollable::shouldDrawItem(float elemHeight, float elemOffset) const
+{
+	float elemPos = elemOffset + this->scrollOffset;
+	return (elemPos < this->scrollArea.getSize().y) && (elemPos + elemHeight > 0);
+}
+
+bool Scrollable::isWithinScrollArea(sf::Vector2f point) const
+{
+	return this->scrollArea.getLocalBounds().contains(point);
+}
+
+float Scrollable::getScrollOffset() const
+{
+	return this->scrollOffset;
+}
+
+void Scrollable::handleScroll(float delta, sf::Vector2i mousePos)
+{
+	if (this->scrollableContentHeight <= this->scrollArea.getSize().y)
+		return; // scrollable content fits entirely inside scroll area - don't scroll
+
+	if ((delta < 0 && this->scrollOffset == this->bottomScrollLimit) || (delta > 0 && this->scrollOffset == 0))
+		return; // already scrolled to the max position in the desired direction, nothing to do
+
+	mousePos -= this->getPosition();
+
+	// ignore event if mouse was outside Scrollable's area
+	if (!this->isWithinScrollArea(static_cast<sf::Vector2f>(mousePos)))
+		return;
+
+	// can't use ::move(), since it would effectively prevent the component to be placed
+	// at a desired position (vertically)
+	this->scrollOffset += delta * calculateGuiAwareScalar(SCROLL_FACTOR);
+
+	// limit scrolling to the top
+	if (this->scrollOffset > 0)
+		this->scrollOffset = 0;
+
+	// limit scrolling to the bottom
+	if (this->scrollOffset < this->bottomScrollLimit)
+		this->scrollOffset = this->bottomScrollLimit;
+
+	// note: as an alternative approach to redrawing the texture after each scroll event, we could instead render all
+	// items into a tall texture, and just draw it with some offset (and mask it). however, this could consume a lot of
+	// GPU memory if there are a lot of items.
+	this->redrawScrollableContent(false);
+}
+
+void Scrollable::handleSettingsChange()
+{
+	this->handleGuiScaleChange();
+	this->setGuiScale();
+
+	// scroll limit depends on scrollable area size, which can change along with GUI scale.
+	// derived class should call ::handleScrollableContentHeightChanged(), which will update scroll limit and redraw
+	// scrollable content
+	// note: current scroll position would change slightly
+}
+
+void Scrollable::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+	target.draw(this->scrollableContentSprite, states);
+}

--- a/src/hud/scrollable/scrollable.cpp
+++ b/src/hud/scrollable/scrollable.cpp
@@ -152,7 +152,10 @@ void Scrollable::handleScroll(float delta, sf::Vector2i mousePos)
 
 void Scrollable::updateScrollbar()
 {
-	this->scrollbar.setValue(this->scrollOffset * SCROLLBAR_MAX_VALUE / this->bottomScrollLimit);
+	this->showScrollbar = this->scrollableContentHeight > this->scrollArea.getSize().y;
+
+	if (this->showScrollbar)
+		this->scrollbar.setValue(this->scrollOffset * SCROLLBAR_MAX_VALUE / this->bottomScrollLimit);
 }
 
 /**
@@ -169,7 +172,7 @@ ClickStatus Scrollable::handleLeftClick(sf::Vector2i clickPos)
 {
 	clickPos -= this->getPosition();
 
-	if (this->scrollbar.handleLeftClick(clickPos))
+	if (this->showScrollbar && this->scrollbar.handleLeftClick(clickPos))
 	{
 		this->handleScrollbarMoved();
 		return CLICK_CONSUMED;
@@ -180,14 +183,15 @@ ClickStatus Scrollable::handleLeftClick(sf::Vector2i clickPos)
 
 void Scrollable::handleLeftClickUp()
 {
-	this->scrollbar.handleLeftClickUp();
+	if (this->showScrollbar)
+		this->scrollbar.handleLeftClickUp();
 }
 
 bool Scrollable::handleMouseMove(sf::Vector2i mousePos)
 {
 	mousePos -= this->getPosition();
 
-	if (this->scrollbar.handleMouseMove(mousePos))
+	if (this->showScrollbar && this->scrollbar.handleMouseMove(mousePos))
 	{
 		this->handleScrollbarMoved();
 		return true;
@@ -211,5 +215,7 @@ void Scrollable::handleSettingsChange()
 void Scrollable::draw(sf::RenderTarget& target, sf::RenderStates states) const
 {
 	target.draw(this->scrollableContentSprite, states);
-	target.draw(this->scrollbar, states);
+
+	if (this->showScrollbar)
+		target.draw(this->scrollbar, states);
 }

--- a/src/hud/scrollable/scrollable.hpp
+++ b/src/hud/scrollable/scrollable.hpp
@@ -31,6 +31,10 @@ enum ScrollPosition
  *
  * Component which inherits Scrollable should always notify the base class when the scrollable content height changes
  * (via ::handleScrollableContentHeightChanged()). This ensures that scroll limits and scroll bar will behave correctly.
+ *
+ * The scroll bar id displayed on the right side of scrollable content and is the same height as scrollable area.
+ * It's drawn alongside the scrollable area, so the total width of Scrollable is
+ * scrollableAreaSize.x + SLIDER_HANDLE_THICKNESS.
  */
 class Scrollable : public sf::Drawable, public GuiTransformable
 {

--- a/src/hud/scrollable/scrollable.hpp
+++ b/src/hud/scrollable/scrollable.hpp
@@ -13,7 +13,10 @@
 #include <SFML/Graphics/Sprite.hpp>
 #include <SFML/System/Vector2.hpp>
 
+#include "../../resources/resource_manager.hpp"
+#include "../clickable.hpp"
 #include "../gui_transformable.hpp"
+#include "../sliders/int_slider.hpp"
 
 enum ScrollPosition
 {
@@ -39,7 +42,10 @@ class Scrollable : public sf::Drawable, public GuiTransformable
 		sf::Sprite scrollableContentSprite;
 		sf::RectangleShape scrollArea;
 		const sf::Vector2f scrollableAreaSize; // original size, GUI-independent
+		IntSlider scrollbar;
 		void setGuiScale();
+		void updateScrollbar();
+		void handleScrollbarMoved();
 
 	protected:
 		void redrawScrollableContent(bool resize);
@@ -51,8 +57,11 @@ class Scrollable : public sf::Drawable, public GuiTransformable
 		virtual void drawScrollableContent(sf::RenderTarget& target, sf::RenderStates states) = 0;
 
 	public:
-		explicit Scrollable(const sf::Vector2f& scrollableAreaSize);
+		Scrollable(ResourceManager& resMgr, const sf::Vector2f& scrollableAreaSize);
 		void handleScroll(float delta, sf::Vector2i mousePos);
+		virtual ClickStatus handleLeftClick(sf::Vector2i clickPos);
+		void handleLeftClickUp();
+		bool handleMouseMove(sf::Vector2i mousePos);
 		void handleSettingsChange() override;
 		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 };

--- a/src/hud/scrollable/scrollable.hpp
+++ b/src/hud/scrollable/scrollable.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// (c) 2024 h67ma <szycikm@gmail.com>
+
+#pragma once
+
+#include <memory>
+
+#include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Graphics/RenderTexture.hpp>
+#include <SFML/Graphics/Sprite.hpp>
+#include <SFML/System/Vector2.hpp>
+
+#include "../gui_transformable.hpp"
+
+enum ScrollPosition
+{
+	SCROLL_TOP,
+	SCROLL_UNCHANGED,
+	SCROLL_BOTTOM,
+};
+
+/**
+ * Abstract class for components which contain scrollable content. Components inheriting from it should not inherit
+ * sf::Drawable nor sf::Transformable. Instead, they should implement ::drawScrollableContent().
+ *
+ * Component which inherits Scrollable should always notify the base class when the scrollable content height changes
+ * (via ::handleScrollableContentHeightChanged()). This ensures that scroll limits and scroll bar will behave correctly.
+ */
+class Scrollable : public sf::Drawable, public GuiTransformable
+{
+	private:
+		float scrollOffset = 0;
+		float scrollableContentHeight;
+		float bottomScrollLimit;
+		std::unique_ptr<sf::RenderTexture> scrollableContentTexture;
+		sf::Sprite scrollableContentSprite;
+		sf::RectangleShape scrollArea;
+		const sf::Vector2f scrollableAreaSize; // original size, GUI-independent
+		void setGuiScale();
+
+	protected:
+		void redrawScrollableContent(bool resize);
+		void handleScrollableContentHeightChanged(float newHeight, enum ScrollPosition scrollTo = SCROLL_UNCHANGED,
+												  bool resize = false);
+		bool shouldDrawItem(float elemHeight, float elemOffset) const;
+		bool isWithinScrollArea(sf::Vector2f point) const;
+		float getScrollOffset() const;
+		virtual void drawScrollableContent(sf::RenderTarget& target, sf::RenderStates states) = 0;
+
+	public:
+		explicit Scrollable(const sf::Vector2f& scrollableAreaSize);
+		void handleScroll(float delta, sf::Vector2i mousePos);
+		void handleSettingsChange() override;
+		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
+};

--- a/src/hud/scrollable/scrollable.hpp
+++ b/src/hud/scrollable/scrollable.hpp
@@ -47,6 +47,7 @@ class Scrollable : public sf::Drawable, public GuiTransformable
 		sf::RectangleShape scrollArea;
 		const sf::Vector2f scrollableAreaSize; // original size, GUI-independent
 		IntSlider scrollbar;
+		bool showScrollbar = false; // automatically hide and disable scrollbar when the content fits entirely
 		void setGuiScale();
 		void updateScrollbar();
 		void handleScrollbarMoved();

--- a/src/hud/scrollable/text_list_view.cpp
+++ b/src/hud/scrollable/text_list_view.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// (c) 2024 h67ma <szycikm@gmail.com>
+
+#include "text_list_view.hpp"
+
+#include "../../settings/settings_manager.hpp"
+
+constexpr float TEXT_V_MARGIN = 5;
+
+TextListView::TextListView(ResourceManager& resMgr, enum FontType fontType, uint fontSize,
+						   const sf::Vector2f& scrollableAreaSize, std::deque<StringAndColor>& items) :
+	ListView(scrollableAreaSize, resMgr.getFont(fontType)->getLineSpacing(fontSize) + TEXT_V_MARGIN, items),
+	viewHolder(*resMgr.getFont(fontType), fontSize)
+{
+}
+
+const TextLabel& TextListView::bindViewHolder(const StringAndColor& item)
+{
+	this->viewHolder.setString(item.first);
+	this->viewHolder.setFillColor(item.second);
+
+	return this->viewHolder;
+}
+
+void TextListView::handleSettingsChange()
+{
+	this->viewHolder.handleSettingsChange();
+	ListView::handleSettingsChange();
+}

--- a/src/hud/scrollable/text_list_view.cpp
+++ b/src/hud/scrollable/text_list_view.cpp
@@ -10,7 +10,7 @@ constexpr float TEXT_V_MARGIN = 5;
 
 TextListView::TextListView(ResourceManager& resMgr, enum FontType fontType, uint fontSize,
 						   const sf::Vector2f& scrollableAreaSize, std::deque<StringAndColor>& items) :
-	ListView(scrollableAreaSize, resMgr.getFont(fontType)->getLineSpacing(fontSize) + TEXT_V_MARGIN, items),
+	ListView(resMgr, scrollableAreaSize, resMgr.getFont(fontType)->getLineSpacing(fontSize) + TEXT_V_MARGIN, items),
 	viewHolder(*resMgr.getFont(fontType), fontSize)
 {
 }

--- a/src/hud/scrollable/text_list_view.hpp
+++ b/src/hud/scrollable/text_list_view.hpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// (c) 2024 h67ma <szycikm@gmail.com>
+
+#pragma once
+
+#include <deque>
+
+#include "../../consts.hpp"
+#include "../../resources/resource_manager.hpp"
+#include "../text_label.hpp"
+#include "list_view.hpp"
+
+/**
+ * A ListView which items are one-line text elements.
+ * Allows setting a different text color for each item.
+ * Items are stored in a deque, because they are likely to be added/removed (e.g. in case of log)
+ */
+class TextListView : public ListView<TextLabel, StringAndColor, std::deque>
+{
+	private:
+		TextLabel viewHolder;
+		const TextLabel& bindViewHolder(const StringAndColor& item) override;
+
+	public:
+		TextListView(ResourceManager& resMgr, enum FontType fontType, uint fontSize,
+					 const sf::Vector2f& scrollableAreaSize, std::deque<StringAndColor>& items);
+		void handleSettingsChange() override;
+};

--- a/src/hud/sliders/float_slider.cpp
+++ b/src/hud/sliders/float_slider.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #include "float_slider.hpp"
 
@@ -16,8 +16,9 @@ constexpr uint BASE10 = 10;
  * @param decimalPlaces controls how many decimal places are displayed in text next to the slider, as well as how
  *						precisely the value can be set
  */
-FloatSlider::FloatSlider(const sf::Font& font, float minVal, float defaultVal, float maxVal, uint decimalPlaces) :
-	Slider(font),
+FloatSlider::FloatSlider(const sf::Font& font, bool showValueText, float minVal, float defaultVal, float maxVal,
+						 uint decimalPlaces) :
+	Slider(font, showValueText),
 	minVal(minVal),
 	maxVal(maxVal),
 	currentVal(defaultVal),
@@ -68,6 +69,9 @@ void FloatSlider::setValue(float value)
 
 void FloatSlider::updateText()
 {
+	if (!this->showValueText)
+		return;
+
 	std::stringstream stream;
 	stream << std::fixed << std::setprecision(this->decimalPlaces) << this->currentVal;
 	this->currValueText.setString(stream.str());

--- a/src/hud/sliders/float_slider.cpp
+++ b/src/hud/sliders/float_slider.cpp
@@ -16,9 +16,9 @@ constexpr uint BASE10 = 10;
  * @param decimalPlaces controls how many decimal places are displayed in text next to the slider, as well as how
  *						precisely the value can be set
  */
-FloatSlider::FloatSlider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText, float minVal,
-						 float defaultVal, float maxVal, uint decimalPlaces) :
-	Slider(orientation, font, showValueText),
+FloatSlider::FloatSlider(enum SliderOrientation orientation, uint sliderLength, const sf::Font& font,
+						 bool showValueText, float minVal, float defaultVal, float maxVal, uint decimalPlaces) :
+	Slider(orientation, sliderLength, font, showValueText),
 	minVal(minVal),
 	maxVal(maxVal),
 	currentVal(defaultVal),
@@ -35,7 +35,7 @@ FloatSlider::FloatSlider(enum SliderOrientation orientation, const sf::Font& fon
 
 void FloatSlider::setValueFromMouse(int mouseValue)
 {
-	this->currentVal = (static_cast<float>(mouseValue) * this->possibleValCnt / Slider::adjustedPossibleMouseValCnt /
+	this->currentVal = (static_cast<float>(mouseValue) * this->possibleValCnt / this->adjustedPossibleMouseValCnt /
 						this->precisionFactor) +
 					   this->minVal;
 
@@ -70,7 +70,7 @@ void FloatSlider::updateHandle()
 {
 	float pos =
 		std::ceil((this->currentVal - this->minVal) / static_cast<float>(this->possibleValCnt) *
-				  static_cast<float>(Slider::adjustedPossibleMouseValCnt) * static_cast<float>(this->precisionFactor));
+				  static_cast<float>(this->adjustedPossibleMouseValCnt) * static_cast<float>(this->precisionFactor));
 
 	if (this->orientation == SLIDER_HORIZONTAL)
 		this->handle.setPosition(pos, 0);

--- a/src/hud/sliders/float_slider.cpp
+++ b/src/hud/sliders/float_slider.cpp
@@ -16,9 +16,9 @@ constexpr uint BASE10 = 10;
  * @param decimalPlaces controls how many decimal places are displayed in text next to the slider, as well as how
  *						precisely the value can be set
  */
-FloatSlider::FloatSlider(const sf::Font& font, bool showValueText, float minVal, float defaultVal, float maxVal,
-						 uint decimalPlaces) :
-	Slider(font, showValueText),
+FloatSlider::FloatSlider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText, float minVal,
+						 float defaultVal, float maxVal, uint decimalPlaces) :
+	Slider(orientation, font, showValueText),
 	minVal(minVal),
 	maxVal(maxVal),
 	currentVal(defaultVal),
@@ -33,26 +33,15 @@ FloatSlider::FloatSlider(const sf::Font& font, bool showValueText, float minVal,
 	this->handleSettingsChange();
 }
 
-void FloatSlider::setSliderPos(int mouseX)
+void FloatSlider::setValueFromMouse(int mouseValue)
 {
-	mouseX -= Slider::adjustedHandleHalf;
-
-	if (mouseX < 0)
-		mouseX = 0;
-
-	if (mouseX > Slider::adjustedPossibleMouseValCnt)
-		mouseX = Slider::adjustedPossibleMouseValCnt;
-
-	this->currentVal = (static_cast<float>(mouseX) * this->possibleValCnt / Slider::adjustedPossibleMouseValCnt /
+	this->currentVal = (static_cast<float>(mouseValue) * this->possibleValCnt / Slider::adjustedPossibleMouseValCnt /
 						this->precisionFactor) +
 					   this->minVal;
 
 	this->currentVal = floorf(this->currentVal * this->precisionFactor) / this->precisionFactor;
 
 	this->updateText();
-
-	// no need to call updateHandle() since it would needlessly calculate X from currentVal, and we already have X
-	this->handle.setPosition(static_cast<float>(mouseX), 0);
 }
 
 float FloatSlider::getValue() const
@@ -79,7 +68,12 @@ void FloatSlider::updateText()
 
 void FloatSlider::updateHandle()
 {
-	float x = (this->currentVal - this->minVal) / this->possibleValCnt * Slider::adjustedPossibleMouseValCnt *
-			  this->precisionFactor;
-	this->handle.setPosition(x, 0);
+	float pos =
+		std::ceil((this->currentVal - this->minVal) / static_cast<float>(this->possibleValCnt) *
+				  static_cast<float>(Slider::adjustedPossibleMouseValCnt) * static_cast<float>(this->precisionFactor));
+
+	if (this->orientation == SLIDER_HORIZONTAL)
+		this->handle.setPosition(pos, 0);
+	else
+		this->handle.setPosition(0, pos);
 }

--- a/src/hud/sliders/float_slider.hpp
+++ b/src/hud/sliders/float_slider.hpp
@@ -24,8 +24,8 @@ class FloatSlider : public Slider
 		void setValueFromMouse(int mouseValue) override;
 
 	public:
-		FloatSlider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText, float minVal,
-					float defaultVal, float maxVal, uint decimalPlaces);
+		FloatSlider(enum SliderOrientation orientation, uint sliderLength, const sf::Font& font, bool showValueText,
+					float minVal, float defaultVal, float maxVal, uint decimalPlaces);
 		float getValue() const;
 		void setValue(float value);
 };

--- a/src/hud/sliders/float_slider.hpp
+++ b/src/hud/sliders/float_slider.hpp
@@ -21,11 +21,11 @@ class FloatSlider : public Slider
 
 		void updateText();
 		void updateHandle() override;
-		void setSliderPos(int mouseX) override;
+		void setValueFromMouse(int mouseValue) override;
 
 	public:
-		FloatSlider(const sf::Font& font, bool showValueText, float minVal, float defaultVal, float maxVal,
-					uint decimalPlaces);
+		FloatSlider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText, float minVal,
+					float defaultVal, float maxVal, uint decimalPlaces);
 		float getValue() const;
 		void setValue(float value);
 };

--- a/src/hud/sliders/float_slider.hpp
+++ b/src/hud/sliders/float_slider.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #pragma once
 
@@ -24,7 +24,8 @@ class FloatSlider : public Slider
 		void setSliderPos(int mouseX) override;
 
 	public:
-		FloatSlider(const sf::Font& font, float minVal, float defaultVal, float maxVal, uint decimalPlaces);
+		FloatSlider(const sf::Font& font, bool showValueText, float minVal, float defaultVal, float maxVal,
+					uint decimalPlaces);
 		float getValue() const;
 		void setValue(float value);
 };

--- a/src/hud/sliders/int_slider.cpp
+++ b/src/hud/sliders/int_slider.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #include "int_slider.hpp"
 
@@ -8,8 +8,8 @@
 
 #include <string>
 
-IntSlider::IntSlider(const sf::Font& font, int minVal, int defaultVal, int maxVal) :
-	Slider(font),
+IntSlider::IntSlider(const sf::Font& font, bool showValueText, int minVal, int defaultVal, int maxVal) :
+	Slider(font, showValueText),
 	minVal(minVal),
 	maxVal(maxVal),
 	currentVal(defaultVal),
@@ -54,6 +54,9 @@ void IntSlider::setValue(int value)
 
 void IntSlider::updateText()
 {
+	if (!this->showValueText)
+		return;
+
 	this->currValueText.setString(std::to_string(this->currentVal));
 }
 

--- a/src/hud/sliders/int_slider.cpp
+++ b/src/hud/sliders/int_slider.cpp
@@ -5,11 +5,13 @@
 #include "int_slider.hpp"
 
 #include <cassert>
+#include <cmath>
 
 #include <string>
 
-IntSlider::IntSlider(const sf::Font& font, bool showValueText, int minVal, int defaultVal, int maxVal) :
-	Slider(font, showValueText),
+IntSlider::IntSlider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText, int minVal,
+					 int defaultVal, int maxVal) :
+	Slider(orientation, font, showValueText),
 	minVal(minVal),
 	maxVal(maxVal),
 	currentVal(defaultVal),
@@ -22,22 +24,11 @@ IntSlider::IntSlider(const sf::Font& font, bool showValueText, int minVal, int d
 	this->handleSettingsChange();
 }
 
-void IntSlider::setSliderPos(int mouseX)
+void IntSlider::setValueFromMouse(int mouseValue)
 {
-	mouseX -= Slider::adjustedHandleHalf;
-
-	if (mouseX < 0)
-		mouseX = 0;
-
-	if (mouseX > Slider::adjustedPossibleMouseValCnt)
-		mouseX = Slider::adjustedPossibleMouseValCnt;
-
-	this->currentVal = (mouseX * this->possibleValCnt / Slider::adjustedPossibleMouseValCnt) + this->minVal;
+	this->currentVal = (mouseValue * this->possibleValCnt / Slider::adjustedPossibleMouseValCnt) + this->minVal;
 
 	this->updateText();
-
-	// no need to call updateHandle() since it would needlessly calculate X from currentVal, and we already have X
-	this->handle.setPosition(static_cast<float>(mouseX), 0);
 }
 
 int IntSlider::getValue() const
@@ -62,7 +53,12 @@ void IntSlider::updateText()
 
 void IntSlider::updateHandle()
 {
-	float x = static_cast<float>(this->currentVal - this->minVal) / this->possibleValCnt *
-			  Slider::adjustedPossibleMouseValCnt;
-	this->handle.setPosition(x, 0);
+	float pos =
+		std::ceil(static_cast<float>(this->currentVal - this->minVal) / static_cast<float>(this->possibleValCnt) *
+				  static_cast<float>(Slider::adjustedPossibleMouseValCnt));
+
+	if (this->orientation == SLIDER_HORIZONTAL)
+		this->handle.setPosition(pos, 0);
+	else
+		this->handle.setPosition(0, pos);
 }

--- a/src/hud/sliders/int_slider.cpp
+++ b/src/hud/sliders/int_slider.cpp
@@ -9,9 +9,9 @@
 
 #include <string>
 
-IntSlider::IntSlider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText, int minVal,
-					 int defaultVal, int maxVal) :
-	Slider(orientation, font, showValueText),
+IntSlider::IntSlider(enum SliderOrientation orientation, uint sliderLength, const sf::Font& font, bool showValueText,
+					 int minVal, int defaultVal, int maxVal) :
+	Slider(orientation, sliderLength, font, showValueText),
 	minVal(minVal),
 	maxVal(maxVal),
 	currentVal(defaultVal),
@@ -26,7 +26,7 @@ IntSlider::IntSlider(enum SliderOrientation orientation, const sf::Font& font, b
 
 void IntSlider::setValueFromMouse(int mouseValue)
 {
-	this->currentVal = (mouseValue * this->possibleValCnt / Slider::adjustedPossibleMouseValCnt) + this->minVal;
+	this->currentVal = (mouseValue * this->possibleValCnt / this->adjustedPossibleMouseValCnt) + this->minVal;
 
 	this->updateText();
 }
@@ -55,7 +55,7 @@ void IntSlider::updateHandle()
 {
 	float pos =
 		std::ceil(static_cast<float>(this->currentVal - this->minVal) / static_cast<float>(this->possibleValCnt) *
-				  static_cast<float>(Slider::adjustedPossibleMouseValCnt));
+				  static_cast<float>(this->adjustedPossibleMouseValCnt));
 
 	if (this->orientation == SLIDER_HORIZONTAL)
 		this->handle.setPosition(pos, 0);

--- a/src/hud/sliders/int_slider.hpp
+++ b/src/hud/sliders/int_slider.hpp
@@ -16,10 +16,11 @@ class IntSlider : public Slider
 
 		void updateText();
 		void updateHandle() override;
-		void setSliderPos(int mouseX) override;
+		void setValueFromMouse(int mouseValue) override;
 
 	public:
-		IntSlider(const sf::Font& font, bool showValueText, int minVal, int defaultVal, int maxVal);
+		IntSlider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText, int minVal,
+				  int defaultVal, int maxVal);
 		int getValue() const;
 		void setValue(int value);
 };

--- a/src/hud/sliders/int_slider.hpp
+++ b/src/hud/sliders/int_slider.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #pragma once
 
@@ -19,7 +19,7 @@ class IntSlider : public Slider
 		void setSliderPos(int mouseX) override;
 
 	public:
-		IntSlider(const sf::Font& font, int minVal, int defaultVal, int maxVal);
+		IntSlider(const sf::Font& font, bool showValueText, int minVal, int defaultVal, int maxVal);
 		int getValue() const;
 		void setValue(int value);
 };

--- a/src/hud/sliders/int_slider.hpp
+++ b/src/hud/sliders/int_slider.hpp
@@ -19,8 +19,8 @@ class IntSlider : public Slider
 		void setValueFromMouse(int mouseValue) override;
 
 	public:
-		IntSlider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText, int minVal,
-				  int defaultVal, int maxVal);
+		IntSlider(enum SliderOrientation orientation, uint sliderLength, const sf::Font& font, bool showValueText,
+				  int minVal, int defaultVal, int maxVal);
 		int getValue() const;
 		void setValue(int value);
 };

--- a/src/hud/sliders/slider.cpp
+++ b/src/hud/sliders/slider.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #include "slider.hpp"
 
@@ -24,7 +24,7 @@ constexpr float SLIDER_OUTLINE_THICKNESS = 1;
 uint Slider::adjustedHandleHalf;
 uint Slider::adjustedPossibleMouseValCnt;
 
-Slider::Slider(const sf::Font& font) : currValueText(font, FONT_H3)
+Slider::Slider(const sf::Font& font, bool showValueText) : currValueText(font, FONT_H3), showValueText(showValueText)
 {
 	this->sliderOutline.setFillColor(sf::Color::Transparent);
 }
@@ -90,10 +90,13 @@ void Slider::handleSettingsChange()
 
 	this->sliderOutline.setOutlineColor(DIM_COLOR(SettingsManager::hudColor, SLIDER_COLOR_DIM_FACTOR));
 
-	this->currValueText.setPosition(calculateGuiAwarePoint({ SLIDER_TEXT_X, getFontVOffset(FONT_H3) }));
+	if (this->showValueText)
+	{
+		this->currValueText.setPosition(calculateGuiAwarePoint({ SLIDER_TEXT_X, getFontVOffset(FONT_H3) }));
 
-	this->currValueText.handleSettingsChange();
-	this->currValueText.setFillColor(SettingsManager::hudColor);
+		this->currValueText.handleSettingsChange();
+		this->currValueText.setFillColor(SettingsManager::hudColor);
+	}
 
 	this->handle.handleSettingsChange();
 }
@@ -103,6 +106,9 @@ void Slider::draw(sf::RenderTarget& target, sf::RenderStates states) const
 	states.transform *= this->getTransform();
 
 	target.draw(this->sliderOutline, states);
-	target.draw(this->currValueText, states);
+
+	if (this->showValueText)
+		target.draw(this->currValueText, states);
+
 	target.draw(this->handle, states);
 }

--- a/src/hud/sliders/slider.cpp
+++ b/src/hud/sliders/slider.cpp
@@ -10,6 +10,7 @@
 #include "../../settings/settings_manager.hpp"
 #include "../../util/util.hpp"
 #include "../hud.hpp"
+#include "slider_consts.hpp"
 
 constexpr float SLIDER_TEXT_X = 220;
 constexpr uint SLIDER_TEXT_Y_PADDING = 5;

--- a/src/hud/sliders/slider.cpp
+++ b/src/hud/sliders/slider.cpp
@@ -11,20 +11,26 @@
 #include "../../util/util.hpp"
 #include "../hud.hpp"
 
-constexpr uint SLIDER_TEXT_X = 220;
+constexpr float SLIDER_TEXT_X = 220;
+constexpr uint SLIDER_TEXT_Y_PADDING = 5;
 constexpr uchar SLIDER_COLOR_DIM_FACTOR = 200;
 
-constexpr uint SLIDER_WIDTH = 215;
-constexpr uint SLIDER_HANDLE_HALF = SLIDER_HANDLE_WIDTH / 2;
-constexpr uint SLIDER_MOUSE_POSSIBLE_VALS = SLIDER_WIDTH - SLIDER_HANDLE_WIDTH;
+constexpr uint SLIDER_LENGTH = 215;
+constexpr uint SLIDER_HANDLE_HALF = SLIDER_HANDLE_LENGTH / 2;
+constexpr uint SLIDER_MOUSE_POSSIBLE_VALS = SLIDER_LENGTH - SLIDER_HANDLE_LENGTH;
 
-const sf::Vector2f sliderOutlineSize(SLIDER_WIDTH, SLIDER_HANDLE_HEIGHT);
+const sf::Vector2f hSliderOutlineSize(SLIDER_LENGTH, SLIDER_HANDLE_THICKNESS);
+const sf::Vector2f vSliderOutlineSize(SLIDER_HANDLE_THICKNESS, SLIDER_LENGTH);
 constexpr float SLIDER_OUTLINE_THICKNESS = 1;
 
 uint Slider::adjustedHandleHalf;
 uint Slider::adjustedPossibleMouseValCnt;
 
-Slider::Slider(const sf::Font& font, bool showValueText) : currValueText(font, FONT_H3), showValueText(showValueText)
+Slider::Slider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText) :
+	currValueText(font, FONT_H3),
+	showValueText(showValueText),
+	orientation(orientation),
+	handle(orientation)
 {
 	this->sliderOutline.setFillColor(sf::Color::Transparent);
 }
@@ -50,7 +56,12 @@ bool Slider::handleLeftClick(sf::Vector2i clickPos)
 	if (this->sliderOutline.getLocalBounds().contains(static_cast<sf::Vector2f>(clickPos)))
 	{
 		this->dragging = true;
-		this->setSliderPos(clickPos.x);
+
+		if (this->orientation == SLIDER_HORIZONTAL)
+			this->setSliderPosH(clickPos.x);
+		else
+			this->setSliderPosV(clickPos.y);
+
 		return true;
 	}
 
@@ -71,11 +82,53 @@ bool Slider::handleMouseMove(sf::Vector2i mousePos)
 	if (!dragging)
 		return false;
 
-	// we don't need to subtract y here
-	mousePos.x -= this->getPosition().x;
+	if (this->orientation == SLIDER_HORIZONTAL)
+	{
+		// we don't need to subtract y
+		mousePos.x -= this->getPosition().x;
 
-	this->setSliderPos(mousePos.x);
+		this->setSliderPosH(mousePos.x);
+	}
+	else
+	{
+		// we don't need to subtract x
+		mousePos.y -= this->getPosition().y;
+
+		this->setSliderPosV(mousePos.y);
+	}
+
 	return true;
+}
+
+int Slider::trimSliderPos(int mouseValue)
+{
+	mouseValue -= Slider::adjustedHandleHalf;
+
+	if (mouseValue < 0)
+		mouseValue = 0;
+
+	if (mouseValue > Slider::adjustedPossibleMouseValCnt)
+		mouseValue = Slider::adjustedPossibleMouseValCnt;
+
+	return mouseValue;
+}
+
+void Slider::setSliderPosH(int mouseX)
+{
+	mouseX = trimSliderPos(mouseX);
+	this->setValueFromMouse(mouseX);
+
+	// no need to call updateHandle() since it would needlessly calculate X from currentVal, and we already have X
+	this->handle.setPosition(static_cast<float>(mouseX), 0);
+}
+
+void Slider::setSliderPosV(int mouseY)
+{
+	mouseY = trimSliderPos(mouseY);
+	this->setValueFromMouse(mouseY);
+
+	// no need to call updateHandle() since it would needlessly calculate Y from currentVal, and we already have Y
+	this->handle.setPosition(0, static_cast<float>(mouseY));
 }
 
 void Slider::handleSettingsChange()
@@ -86,13 +139,20 @@ void Slider::handleSettingsChange()
 
 	this->sliderOutline.setOutlineThickness(calculateGuiAwareScalar(SLIDER_OUTLINE_THICKNESS));
 
-	this->sliderOutline.setSize(calculateGuiAwarePoint(sliderOutlineSize));
+	if (this->orientation == SLIDER_HORIZONTAL)
+		this->sliderOutline.setSize(calculateGuiAwarePoint(hSliderOutlineSize));
+	else
+		this->sliderOutline.setSize(calculateGuiAwarePoint(vSliderOutlineSize));
 
 	this->sliderOutline.setOutlineColor(DIM_COLOR(SettingsManager::hudColor, SLIDER_COLOR_DIM_FACTOR));
 
 	if (this->showValueText)
 	{
-		this->currValueText.setPosition(calculateGuiAwarePoint({ SLIDER_TEXT_X, getFontVOffset(FONT_H3) }));
+		if (this->orientation == SLIDER_HORIZONTAL)
+			this->currValueText.setPosition(calculateGuiAwarePoint({ SLIDER_TEXT_X, getFontVOffset(FONT_H3) }));
+		else
+			this->currValueText.setPosition(
+				calculateGuiAwarePoint({ 0, -static_cast<float>(SLIDER_TEXT_Y_PADDING + FONT_H3) }));
 
 		this->currValueText.handleSettingsChange();
 		this->currValueText.setFillColor(SettingsManager::hudColor);

--- a/src/hud/sliders/slider.hpp
+++ b/src/hud/sliders/slider.hpp
@@ -13,6 +13,9 @@
 #include "slider_handle.hpp"
 #include "slider_orientation.hpp"
 
+// common length of a horizontal slider used to set some value
+constexpr uint INPUT_SLIDER_LENGTH = 215;
+
 /**
  * A base class for a UI component that allows inputting a value in a designated range by dragging or clicking mouse
  * on a bar. Derived classes implement either integer or floating point value sliders.
@@ -22,26 +25,25 @@ class Slider : public GuiTransformable, public sf::Drawable
 	private:
 		sf::RectangleShape sliderOutline;
 		bool dragging = false;
-		static uint adjustedHandleHalf;
+		uint adjustedHandleHalf;
+		const uint sliderLength;
+		const uint possibleMouseVals;
 		virtual void updateHandle() = 0;
 		virtual void setValueFromMouse(int mouseValue) = 0;
-		int trimSliderPos(int mouseValue);
+		int trimSliderPos(int mouseValue) const;
 		void setSliderPosV(int mouseY);
 		void setSliderPosH(int mouseX);
+		void calculateCoeffs();
 
 	protected:
 		const enum SliderOrientation orientation;
 		TextLabel currValueText;
 		const bool showValueText;
 		SliderHandle handle;
-
-		// coefficients can be shared between all instances, as they only depend on GUI scale.
-		// they are also the same for int/float variants
-		static uint adjustedPossibleMouseValCnt;
+		uint adjustedPossibleMouseValCnt;
 
 	public:
-		Slider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText);
-		static void calculateCoeffs();
+		Slider(enum SliderOrientation orientation, uint sliderLength, const sf::Font& font, bool showValueText);
 		bool handleLeftClick(sf::Vector2i clickPos);
 		void handleLeftClickUp();
 		bool handleMouseMove(sf::Vector2i mousePos);

--- a/src/hud/sliders/slider.hpp
+++ b/src/hud/sliders/slider.hpp
@@ -11,31 +11,36 @@
 #include "../gui_transformable.hpp"
 #include "../text_label.hpp"
 #include "slider_handle.hpp"
+#include "slider_orientation.hpp"
 
 /**
  * A base class for a UI component that allows inputting a value in a designated range by dragging or clicking mouse
- * on a horizontal bar. Derived classes implement either integer or floating point value sliders.
+ * on a bar. Derived classes implement either integer or floating point value sliders.
  */
 class Slider : public GuiTransformable, public sf::Drawable
 {
 	private:
 		sf::RectangleShape sliderOutline;
 		bool dragging = false;
+		static uint adjustedHandleHalf;
 		virtual void updateHandle() = 0;
-		virtual void setSliderPos(int mouseX) = 0;
+		virtual void setValueFromMouse(int mouseValue) = 0;
+		int trimSliderPos(int mouseValue);
+		void setSliderPosV(int mouseY);
+		void setSliderPosH(int mouseX);
 
 	protected:
+		const enum SliderOrientation orientation;
 		TextLabel currValueText;
 		const bool showValueText;
 		SliderHandle handle;
 
 		// coefficients can be shared between all instances, as they only depend on GUI scale.
 		// they are also the same for int/float variants
-		static uint adjustedHandleHalf;
 		static uint adjustedPossibleMouseValCnt;
 
 	public:
-		Slider(const sf::Font& font, bool showValueText);
+		Slider(enum SliderOrientation orientation, const sf::Font& font, bool showValueText);
 		static void calculateCoeffs();
 		bool handleLeftClick(sf::Vector2i clickPos);
 		void handleLeftClickUp();

--- a/src/hud/sliders/slider.hpp
+++ b/src/hud/sliders/slider.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #pragma once
 
@@ -26,6 +26,7 @@ class Slider : public GuiTransformable, public sf::Drawable
 
 	protected:
 		TextLabel currValueText;
+		const bool showValueText;
 		SliderHandle handle;
 
 		// coefficients can be shared between all instances, as they only depend on GUI scale.
@@ -34,7 +35,7 @@ class Slider : public GuiTransformable, public sf::Drawable
 		static uint adjustedPossibleMouseValCnt;
 
 	public:
-		explicit Slider(const sf::Font& font);
+		Slider(const sf::Font& font, bool showValueText);
 		static void calculateCoeffs();
 		bool handleLeftClick(sf::Vector2i clickPos);
 		void handleLeftClickUp();

--- a/src/hud/sliders/slider_consts.hpp
+++ b/src/hud/sliders/slider_consts.hpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// (c) 2024 h67ma <szycikm@gmail.com>
+
+#pragma once
+
+constexpr float SLIDER_HANDLE_THICKNESS = 15;

--- a/src/hud/sliders/slider_handle.cpp
+++ b/src/hud/sliders/slider_handle.cpp
@@ -6,6 +6,7 @@
 
 #include "../../settings/settings_manager.hpp"
 #include "../../util/util.hpp"
+#include "slider_consts.hpp"
 
 constexpr uchar SLIDER_HANDLE_COLOR_DIM_FACTOR = 50;
 

--- a/src/hud/sliders/slider_handle.cpp
+++ b/src/hud/sliders/slider_handle.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #include "slider_handle.hpp"
 
@@ -10,13 +10,14 @@
 constexpr uchar SLIDER_HANDLE_COLOR_DIM_FACTOR = 50;
 
 constexpr float HANDLE_OUTLINE_THICKNESS = 1;
-const sf::Vector2f handleOutlineSize(SLIDER_HANDLE_WIDTH, SLIDER_HANDLE_HEIGHT);
+const sf::Vector2f hHandleOutlineSize(SLIDER_HANDLE_LENGTH, SLIDER_HANDLE_THICKNESS);
+const sf::Vector2f vHandleOutlineSize(SLIDER_HANDLE_THICKNESS, SLIDER_HANDLE_LENGTH);
 
-constexpr float SLIDER_HANDLE_THINGY_LINE_HEIGHT = 6;
+constexpr float SLIDER_HANDLE_THINGY_LINE_LENGTH = 7;
 constexpr float SLIDER_HANDLE_THINGY_LINES_X = 7.5;
-constexpr float SLIDER_HANDLE_THINGY_LINE_Y = 5;
+constexpr float SLIDER_HANDLE_THINGY_LINE_Y = 4;
 
-SliderHandle::SliderHandle()
+SliderHandle::SliderHandle(enum SliderOrientation orientation) : orientation(orientation)
 {
 	this->outlineRect.setOutlineThickness(HANDLE_OUTLINE_THICKNESS);
 
@@ -25,21 +26,44 @@ SliderHandle::SliderHandle()
 
 void SliderHandle::handleSettingsChange()
 {
-	this->outlineRect.setSize(calculateGuiAwarePoint(handleOutlineSize));
 	this->outlineRect.setOutlineColor(SettingsManager::hudColor);
 	this->outlineRect.setFillColor(DIM_COLOR(SettingsManager::hudColor, SLIDER_HANDLE_COLOR_DIM_FACTOR));
 
-	for (uint i = 0; i < SLIDER_HANDLE_THINGY_VERT_CNT; i++)
+	if (this->orientation == SLIDER_HORIZONTAL)
 	{
-		this->thingy[i].color = SettingsManager::hudColor;
+		this->outlineRect.setSize(calculateGuiAwarePoint(hHandleOutlineSize));
 
-		if (i % 2 == 0)
-			this->thingy[i].position = sf::Vector2f((SLIDER_HANDLE_THINGY_LINES_X + i) * SettingsManager::guiScale,
-													SLIDER_HANDLE_THINGY_LINE_Y * SettingsManager::guiScale);
-		else
-			this->thingy[i].position = sf::Vector2f((SLIDER_HANDLE_THINGY_LINES_X - 1 + i) * SettingsManager::guiScale,
-													(SLIDER_HANDLE_THINGY_LINE_Y + SLIDER_HANDLE_THINGY_LINE_HEIGHT) *
-														SettingsManager::guiScale);
+		for (uint i = 0; i < SLIDER_HANDLE_THINGY_VERT_CNT; i++)
+		{
+			this->thingy[i].color = SettingsManager::hudColor;
+
+			if (i % 2 == 0)
+				this->thingy[i].position = sf::Vector2f((SLIDER_HANDLE_THINGY_LINES_X + i) * SettingsManager::guiScale,
+														SLIDER_HANDLE_THINGY_LINE_Y * SettingsManager::guiScale);
+			else
+				this->thingy[i].position =
+					sf::Vector2f((SLIDER_HANDLE_THINGY_LINES_X - 1 + i) * SettingsManager::guiScale,
+								 (SLIDER_HANDLE_THINGY_LINE_Y + SLIDER_HANDLE_THINGY_LINE_LENGTH) *
+									 SettingsManager::guiScale);
+		}
+	}
+	else
+	{
+		this->outlineRect.setSize(calculateGuiAwarePoint(vHandleOutlineSize));
+
+		for (uint i = 0; i < SLIDER_HANDLE_THINGY_VERT_CNT; i++)
+		{
+			this->thingy[i].color = SettingsManager::hudColor;
+
+			if (i % 2 == 0)
+				this->thingy[i].position = sf::Vector2f(SLIDER_HANDLE_THINGY_LINE_Y * SettingsManager::guiScale,
+														(SLIDER_HANDLE_THINGY_LINES_X + i) * SettingsManager::guiScale);
+			else
+				this->thingy[i].position =
+					sf::Vector2f((SLIDER_HANDLE_THINGY_LINE_Y + SLIDER_HANDLE_THINGY_LINE_LENGTH) *
+									 SettingsManager::guiScale,
+								 (SLIDER_HANDLE_THINGY_LINES_X - 1 + i) * SettingsManager::guiScale);
+		}
 	}
 }
 

--- a/src/hud/sliders/slider_handle.hpp
+++ b/src/hud/sliders/slider_handle.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #pragma once
 
@@ -11,9 +11,10 @@
 
 #include "../../consts.hpp"
 #include "../configurable_gui_component.hpp"
+#include "slider_orientation.hpp"
 
-constexpr float SLIDER_HANDLE_HEIGHT = 15;
-constexpr float SLIDER_HANDLE_WIDTH = 21;
+constexpr float SLIDER_HANDLE_THICKNESS = 15;
+constexpr float SLIDER_HANDLE_LENGTH = 21;
 
 constexpr uint SLIDER_HANDLE_THINGY_VERT_CNT = 8;
 
@@ -24,12 +25,13 @@ class SliderHandle : public sf::Drawable, public sf::Transformable, public Confi
 {
 	private:
 		sf::RectangleShape outlineRect;
+		const enum SliderOrientation orientation;
 
 		// what else to call something that looks like this |||| ? it's a thingy.
 		sf::VertexArray thingy = sf::VertexArray(sf::Lines, SLIDER_HANDLE_THINGY_VERT_CNT);
 
 	public:
-		SliderHandle();
+		explicit SliderHandle(enum SliderOrientation orientation);
 		void handleSettingsChange() override;
 		void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 };

--- a/src/hud/sliders/slider_handle.hpp
+++ b/src/hud/sliders/slider_handle.hpp
@@ -13,7 +13,6 @@
 #include "../configurable_gui_component.hpp"
 #include "slider_orientation.hpp"
 
-constexpr float SLIDER_HANDLE_THICKNESS = 15;
 constexpr float SLIDER_HANDLE_LENGTH = 21;
 
 constexpr uint SLIDER_HANDLE_THINGY_VERT_CNT = 8;

--- a/src/hud/sliders/slider_orientation.hpp
+++ b/src/hud/sliders/slider_orientation.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// (c) 2024 h67ma <szycikm@gmail.com>
+
+#pragma once
+
+enum SliderOrientation
+{
+	SLIDER_HORIZONTAL,
+	SLIDER_VERTICAL,
+};

--- a/src/hud/text_label.cpp
+++ b/src/hud/text_label.cpp
@@ -1,12 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #include "text_label.hpp"
 
 #include <string>
 
 #include "../settings/settings_manager.hpp"
+
+TextLabel::TextLabel(const std::string& text, const sf::Font& font, uint fontSize, const sf::Color& color,
+					 const sf::Vector2f& position) :
+	fontSize(fontSize)
+{
+	this->setString(text);
+	this->setFont(font);
+	this->setFillColor(color);
+	this->setPosition(position);
+
+	this->handleSettingsChange();
+}
 
 TextLabel::TextLabel(const std::string& text, const sf::Font& font, uint fontSize, const sf::Color& color) :
 	fontSize(fontSize)

--- a/src/hud/text_label.hpp
+++ b/src/hud/text_label.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// (c) 2023 h67ma <szycikm@gmail.com>
+// (c) 2023-2024 h67ma <szycikm@gmail.com>
 
 #pragma once
 
@@ -21,6 +21,8 @@ class TextLabel : public sf::Text, ConfigurableGuiComponent
 		const uint fontSize; // e.g. FONT_H1
 
 	public:
+		TextLabel(const std::string& text, const sf::Font& font, uint fontSize, const sf::Color& color,
+				  const sf::Vector2f& position);
 		TextLabel(const std::string& text, const sf::Font& font, uint fontSize, const sf::Color& color);
 		TextLabel(const std::string& text, const sf::Font& font, uint fontSize);
 		TextLabel(const sf::Font& font, uint fontSize);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,6 +127,10 @@ int main()
 		exit(1);
 	}
 
+	// hook up the Log PipBuck page to receive log messages
+	Log::setMsgAddedCallback([&pipBuck](const std::string& text, const sf::Color& color)
+							 { pipBuck.addLogMessage(text, color); });
+
 	MainMenu mainMenu(resManager, cursorMgr, window, campaign, gameState, pipBuck);
 
 	DevConsole console(window.getSize(), *resManager.getFont(FONT_FIXED), campaign);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,8 +128,7 @@ int main()
 	}
 
 	// hook up the Log PipBuck page to receive log messages
-	Log::setMsgAddedCallback([&pipBuck](const std::string& text, const sf::Color& color)
-							 { pipBuck.addLogMessage(text, color); });
+	Log::setMsgAddedCallback([&pipBuck](const StringAndColor& strAndColor) { pipBuck.addLogMessage(strAndColor); });
 
 	MainMenu mainMenu(resManager, cursorMgr, window, campaign, gameState, pipBuck);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,6 @@
 #include "hud/log.hpp"
 #include "hud/main_menu/main_menu.hpp"
 #include "hud/pipbuck/pipbuck.hpp"
-#include "hud/sliders/slider.hpp"
 #include "resources/resource_manager.hpp"
 #include "settings/keymap.hpp"
 #include "settings/settings_manager.hpp"
@@ -35,7 +34,6 @@
 static void propagateSettings(PipBuck& pipBuck, MainMenu& mainMenu, FpsMeter& fpsMeter, DevConsole& console,
 							  const sf::Vector2u& newWindowSize)
 {
-	Slider::calculateCoeffs();
 	Log::handleSettingsChange();
 	pipBuck.handleSettingsChange();
 	pipBuck.handleScreenResize(newWindowSize);
@@ -88,9 +86,6 @@ int main()
 	Log::handleScreenResize(window.getSize());
 
 	Log::d("Save dir = %s", SettingsManager::getSaveDir().c_str());
-
-	// initial coefficient calculation for all sliders
-	Slider::calculateCoeffs();
 
 	if (!resManager.loadCore())
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -400,6 +400,14 @@ int main()
 
 					continue;
 				}
+
+				if (event.type == sf::Event::MouseWheelScrolled)
+				{
+					pipBuck.handleScroll(event.mouseWheelScroll.delta,
+										 { event.mouseWheelScroll.x, event.mouseWheelScroll.y });
+
+					continue;
+				}
 			}
 			else if (gameState == STATE_MAINMENU)
 			{


### PR DESCRIPTION
Add a container which content can be scrolled with mouse wheel.

Tweak sliders so that they can be used as vertical scrollbars, use one for the newly created scrollable container. Slider shows current scroll position and can be clicked/dragged to set scroll position.

Use a scrollable list of text labels to display log messages on the Log page, and another one to display keybindings on the Controls page.